### PR TITLE
Use .Site.Title (not page .Title) for logo img alt

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,7 +15,7 @@
             <span class="icon-bar"></span>
             </button>
             <a class="navbar-brand" href="{{ .Site.BaseURL }}">
-              <img src="{{ .Site.BaseURL }}img/logo.png" alt="{{ .Title }} Logo">
+              <img src="{{ .Site.BaseURL }}img/logo.png" alt="{{ .Site.Title }} Logo">
             </a>
           </div>
             <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
Hello!  First of all, thank you so much for contributing this beautiful theme to the Hugo community!

The alt text being used for the logo img is currently wrong except for the front page.
instead of saying `alt="Airspace for Hugo Logo"`, it would say `alt="Work Logo"`, `alt="Contact Logo"`, etc. depending on which page the user lands on.

Changing the page-based `.Title` to sitewide `.Site.Title` fixes this issue.

Many thanks!