### PR TITLE
added service section to example site

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -16,7 +16,7 @@ theme = "airspace-hugo"
   [[menu.header]]
     weight = 4
     name = "Service"
-    url = "#"
+    url = "/service"
   [[menu.header]]
     weight = 5
     name = "Contact"

--- a/exampleSite/content/service.md
+++ b/exampleSite/content/service.md
@@ -1,0 +1,4 @@
++++
+title = "Service"
+id = "service"
++++


### PR DESCRIPTION
The example site doesn't have a functional `service` link. Changed the link in the config and added `service.md` 