### PR TITLE
Fix typo and add SPDX short identifier in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Now take a look at the exampleSite folder and you're ready to go!
 
 ## License
 
-While the [original Airspace generic HTML template](https://themefisher.com/products/airspace-free-bootstrap-website-template/) is under the [Creative Common Attribution 3.0 License](https://themefisher.com/license/),  
+While the [original Airspace generic HTML template](https://themefisher.com/products/airspace-free-bootstrap-website-template/) is under the [Creative Commons Attribution 3.0 (CC-BY-3.0) License](https://themefisher.com/license/),  
 **_Airspace_ for Hugo** has been specifically licensed under the [MIT License](https://github.com/themefisher/airspace-hugo/blob/master/LICENSE.md), as our token of appreciation to the [Hugo](https://gohugo.io/) community.
 
 If you like what you see in **_Airspace_ for Hugo**, please spread the word!


### PR DESCRIPTION
"Common" should be "Commons".  Sorry, I didn't catch that.

The same typo is on https://themefisher.com/license/ too, so please fix it when you have time.

Also, on https://themefisher.com/license/, you might want to add a link to https://creativecommons.org/licenses/by/3.0/, https://creativecommons.org/licenses/by/3.0/legalcode, and/or https://spdx.org/licenses/CC-BY-3.0.html so users can read the full text of the license.

Also, just to make sure, you are using "Creative Commons Attribution 3.0 **Unported**" (and not US or other country-specific version), right?