### PR TITLE
Reflect license change in theme.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Now take a look at the exampleSite folder and you're ready to go!
 
 ## License
 
-This Template is released under [Creative Commons Attribution 3.0 (CC-BY-3.0) License](https://creativecommons.org/licenses/by/3.0/)
-If you want to remove the credit simply make a [donation](https://www.paypal.me/Themefisher), so that we can run our contribution to hugo community.
+This Template is released under [Creative Commons Attribution 3.0 (CC-BY-3.0) License](https://creativecommons.org/licenses/by/3.0/).
+If you want to remove the credit, simply make a [donation](https://www.paypal.me/Themefisher) so that we can run our contribution to the Hugo community.
 
 ## About Themefisher
 

--- a/theme.toml
+++ b/theme.toml
@@ -1,7 +1,7 @@
 # theme.toml for the Airspace Hugo theme
 
 name = "Airspace Hugo"
-license = "MIT"
+license = "CC BY 3.0"
 licenselink = "https://github.com/themefisher/airspace-hugo/blob/master/LICENSE"
 description = "Hugo port of the Themefisher’s Airspace theme"
 homepage = "https://github.com/themefisher/airspace-hugo"


### PR DESCRIPTION
This is to ensure https://themes.gohugo.io/airspace-hugo lists the license correctly.
As of this righting, it is still showing MIT as the license.

Also fix the punctuations in the License section in README.md.

Thanks!