### PR TITLE
Collapse equally named categories in work

### DIFF
--- a/layouts/partials/work.html
+++ b/layouts/partials/work.html
@@ -8,9 +8,13 @@
             <div class="block">
               <div class="portfolio-menu">
                 <ul>
-                    <li class="filter" data-filter="all">Everything</li>
+                  {{ $categories := slice }}
                   {{ range .Site.Data.work.portfolio }}
-                    <li class="filter" data-filter=".{{ .category }}">{{ .category }}</li>
+                    {{ $categories = $categories | append .category }}
+                  {{ end }}
+                    <li class="filter" data-filter="all">Everything</li>
+                  {{ range ( $categories | uniq ) }}
+                    <li class="filter" data-filter=".{{ . }}">{{ . }}</li>
                   {{ end }}
                 </ul>
               </div>


### PR DESCRIPTION
Currently if you have multiple elements in the portfolio that are from the same category that category will be added multiple times to the selector. That means that having 4 elements of portfolio, 3 of them having category A, and the forth one having category B the selector will be [Everything, A, A, A, B]. If you click in any of the A selectors will bring ALL elements having category A.

My change will allow only unique categories in the selector, so in the previous example the selector will be [Everything, A, B] and it will behave exactly the same as before.