### PR TITLE
fix installation instruction url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Navigate to your themes folder in your Hugo site and use the following commands:
 ```
 $ mkdir themes
 $ cd themes
-$ git clone https://github.com/Gethugothemes/dot-hugo-documentation-theme.git
+$ git clone https://github.com:themefisher/airspace-hugo.git
 ```
 
 [Full Documentation](http://demo.themefisher.com/airspace-hugo/blog/installation/).


### PR DESCRIPTION
Looks like a recycled README from other page maybe?  Updating to reflect cloning from airspace-hugo repo.