### PR TITLE
use https instead of http for mixed content

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,7 +1,7 @@
 
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,600);
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,100,300,500,700);
-@import url(http://fonts.googleapis.com/css?family=Volkhov:400italic);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,300,600);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,100,300,500,700);
+@import url(https://fonts.googleapis.com/css?family=Volkhov:400italic);
 /*
  * This css file includes styles added in the jekyll port of this theme.
  * To find the original style.css that ships with Airspace, read airspace.css


### PR DESCRIPTION
Some browsers won't allow to load mixed content if it is not via an encrypted channel (see https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)