### PR TITLE
Fix git clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Navigate to your themes folder in your Hugo site and use the following commands:
 ```
 $ mkdir themes
 $ cd themes
-$ git clone https://github.com:themefisher/airspace-hugo.git
+$ git clone https://github.com/themefisher/airspace-hugo.git
 ```
 
 [Full Documentation](http://demo.themefisher.com/airspace-hugo/blog/installation/).


### PR DESCRIPTION
The repo url in the installation section wasn't working. 

Replace github.com: by github.com/