### PR TITLE
Multi-author support

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -129,6 +129,8 @@ location = "North Main Street,Brooklyn Australia"
 contact_form_action = "#" # contact form works with : https://formspree.io
 # Google Analitycs
 google_analitycs_id = "" # Your ID
+# multi-author support (if set to true, you must use an Array in the author field)
+multi_author = false
 
 # Preloader
 [params.preloader]

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -18,7 +18,14 @@
           <div class="post-meta">
             <ul>
               <li><i class="ion-calendar"></i> {{ .PublishDate.Format "January 2, 2006" }}</li>
-              <li><i class="ion-android-people"></i> {{ i18n "posted_by" }} <a class="text-primary" href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize }}">{{ .Params.Author }}</a></li>
+              <li><i class="ion-android-people"></i>
+                {{ i18n "posted_by" }}
+                {{if $.Site.Params.multi_author}}
+                {{ range $index, $elements:= .Params.Author }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
+                {{else}}
+                <a class="text-primary" href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize }}">{{ .Params.Author }}</a>
+                {{end}}
+              </li>
               <li><i class="ion-pricetags"></i> 
                 {{ range $index, $elements:= .Params.Tags }}
                 {{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . | humanize }}</a>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,14 @@
 					<div class="post-meta">
 						<ul>
               <li><i class="ion-calendar"></i> {{ .PublishDate.Format "January 2, 2006" }}</li>
-              <li><i class="ion-android-people"></i> {{ i18n "posted_by" }} <a class="text-primary" href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize }}">{{ .Params.Author }}</a></li>
+              <li><i class="ion-android-people"></i>
+                {{ i18n "posted_by" }}
+                {{if $.Site.Params.multi_author}}
+                {{ range $index, $elements:= .Params.Author }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
+                {{else}}
+                <a class="text-primary" href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize }}">{{ .Params.Author }}</a>
+                {{end}}
+              </li>
               <li><i class="ion-pricetags"></i> 
                 {{ range $index, $elements:= .Params.Tags }}
                 {{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . | humanize }}</a>

--- a/layouts/author/single.html
+++ b/layouts/author/single.html
@@ -43,7 +43,13 @@
 					<h2>{{ i18n "posted_by" }} {{ .Title }}</h2>
 				</div>
 			</div>
-			{{ range where .Site.RegularPages "Params.author" .Title }}
+			{{ $authored_pages := newScratch }}
+			{{ if $.Site.Params.multi_author }}
+			{{ .Scratch.Set "authored_pages" (where .Site.RegularPages "Params.author" "intersect" (slice .Title)) }}
+			{{ else }}
+			{{ .Scratch.Set "authored_pages" (where .Site.RegularPages "Params.author" .Title) }}
+			{{ end }}
+			{{ range (.Scratch.Get "authored_pages") }}
 			<div class="col-md-6">
 				<div class="post">
 					<div class="post-thumb">
@@ -55,7 +61,14 @@
 					<div class="post-meta">
 						<ul>
 							<li><i class="ion-calendar"></i> {{ .PublishDate.Format "January 2, 2006" }}</li>
-              <li><i class="ion-android-people"></i> {{ i18n "posted_by" }} <a class="text-primary" href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize }}">{{ .Params.Author }}</a></li>
+              <li><i class="ion-android-people"></i>
+                {{ i18n "posted_by" }}
+                {{if $.Site.Params.multi_author}}
+                {{ range $index, $elements:= .Params.Author }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
+                {{else}}
+                <a class="text-primary" href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize }}">{{ .Params.Author }}</a>
+                {{end}}
+              </li>
               <li><i class="ion-pricetags"></i> 
                 {{ range $index, $elements:= .Params.Tags }}
                 {{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . | humanize }}</a>


### PR DESCRIPTION
Hi,

Here's a proposal for multi-author support as explained in #71. 
This PR introduces a new site variable named `multi_author`.  

The default value for `multi-author` is `false`: it has been chosen to not introduce any breaking change in the theme.  

When `multi_author` is set to `true`, the `author` parameter in any content MUST be a list.

---

close #71 