### PR TITLE
Fix footer links for multilingual mode

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
 				<div class="footer-manu">
 					<ul>
             {{ range site.Menus.footer }}
-            <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
+            <li><a href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
             {{ end }}
 					</ul>
 				</div>


### PR DESCRIPTION
The footer links always linked to `defaultContentLanguage` pages or – if `defaultContentLanguageInSubdir` was set to `true` in `config.toml` – they were even broken.