### PR TITLE
Use relative home URL

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -12,8 +12,8 @@
               <span class="icon-bar"></span>
               <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="{{ site.BaseURL | relLangURL }}">
-              <img src="{{ site.Params.logo | absURL }}" alt="{{ site.Title }}" width="{{site.Params.logo_width}}" class="img-responsive">
+            <a class="navbar-brand" href="{{ "/" | relLangURL }}">
+              <img src="{{ site.Params.logo | relURL }}" alt="{{ site.Title }}" width="{{site.Params.logo_width}}" class="img-responsive">
             </a>
           </div>
           <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
Replaces `site.BaseURL` with `"/"`. Using relative URLs is generally more portable, for example it allows deploys to other domains than the `BaseURL`, e.g. with [Netlify's branch deploys](https://docs.netlify.com/site-deploys/overview/#branches-and-deploys).