### PR TITLE
Simplify multi-author support

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -87,8 +87,6 @@ location = "North Main Street,Brooklyn Australia"
 contact_form_action = "#" # contact form works with : https://formspree.io
 # Google Analitycs
 google_analitycs_id = "" # Your ID# search
-# multi-author support (if set to true, you must use an Array in the author field)
-multi_author = false
 
 # Preloader
 [params.preloader]

--- a/exampleSite/content/english/blog/blog-post-2.md
+++ b/exampleSite/content/english/blog/blog-post-2.md
@@ -1,7 +1,7 @@
 ---
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
-author: Mark Dinn
+author: [ "Mark Dinn", "John Doe" ]
 image : "images/blog/blog-post-2.jpg"
 bg_image: "images/featue-bg.jpg"
 categories: ["Artificial Intelligence"]

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -23,13 +23,10 @@
               <li><i class="ion-calendar"></i> {{ .PublishDate.Format "January 2, 2006" }}</li>
               <li><i class="ion-android-people"></i>
                 {{ i18n "posted_by" }}
-                {{if site.Params.multi_author}}
-                {{ range $index, $elements:= .Params.Author }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
-                {{else}}
-                <a class="text-primary" href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize }}">{{ .Params.Author }}</a>
-                {{end}}
+                {{ $scratch := newScratch }}{{ if reflect.IsSlice .Params.author }}{{ $scratch.Set "authors" .Params.author }}{{ else }}{{ $scratch.Set "authors" (slice .Params.author) }}{{ end }}
+                {{ range $index, $elements := $scratch.Get "authors" }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
               </li>
-              <li><i class="ion-pricetags"></i> 
+              <li><i class="ion-pricetags"></i>
                 {{ range $index, $elements:= .Params.Tags }}
                 {{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . | humanize }}</a>
 								{{ end }}
@@ -42,7 +39,7 @@
           </div>
         </div>
         {{ end }}
-        
+
 				<!-- pagination -->
 				{{ $paginator := .Paginator }}
 				{{ $adjacent_links := 2 }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,13 +16,10 @@
               <li><i class="ion-calendar"></i> {{ .PublishDate.Format "January 2, 2006" }}</li>
               <li><i class="ion-android-people"></i>
                 {{ i18n "posted_by" }}
-                {{if site.Params.multi_author}}
-                {{ range $index, $elements:= .Params.Author }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
-                {{else}}
-                <a class="text-primary" href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize }}">{{ .Params.Author }}</a>
-                {{end}}
+                {{ $scratch := newScratch }}{{ if reflect.IsSlice .Params.author }}{{ $scratch.Set "authors" .Params.author }}{{ else }}{{ $scratch.Set "authors" (slice .Params.author) }}{{ end }}
+                {{ range $index, $elements := $scratch.Get "authors" }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
               </li>
-              <li><i class="ion-pricetags"></i> 
+              <li><i class="ion-pricetags"></i>
                 {{ range $index, $elements:= .Params.Tags }}
                 {{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . | humanize }}</a>
 								{{ end }}

--- a/layouts/author/single.html
+++ b/layouts/author/single.html
@@ -43,13 +43,7 @@
 					<h2>{{ i18n "posted_by" }} {{ .Title }}</h2>
 				</div>
 			</div>
-			{{ $authored_pages := newScratch }}
-			{{ if site.Params.multi_author }}
-			{{ .Scratch.Set "authored_pages" (where site.RegularPages "Params.author" "intersect" (slice .Title)) }}
-			{{ else }}
-			{{ .Scratch.Set "authored_pages" (where site.RegularPages "Params.author" .Title) }}
-			{{ end }}
-			{{ range (.Scratch.Get "authored_pages") }}
+			{{ range (union (where site.RegularPages "Params.author" "intersect" (slice .Title)) (where site.RegularPages "Params.author" .Title)) }}
 			<div class="col-md-6">
 				<div class="post">
 					<div class="post-thumb">
@@ -63,14 +57,11 @@
 							<li><i class="ion-calendar"></i> {{ .PublishDate.Format "January 2, 2006" }}</li>
               <li><i class="ion-android-people"></i>
                 {{ i18n "posted_by" }}
-                {{if site.Params.multi_author}}
-                {{ range $index, $elements:= .Params.Author }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
-                {{else}}
-                <a class="text-primary" href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize }}">{{ .Params.Author }}</a>
-                {{end}}
+                {{ $scratch := newScratch }}{{ if reflect.IsSlice .Params.author }}{{ $scratch.Set "authors" .Params.author }}{{ else }}{{ $scratch.Set "authors" (slice .Params.author) }}{{ end }}
+                {{ range $index, $elements := $scratch.Get "authors" }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
               </li>
-              <li><i class="ion-pricetags"></i> 
-                {{ range $index, $elements:= .Params.Tags }}
+              <li><i class="ion-pricetags"></i>
+                {{ range $index, $elements := .Params.Tags }}
                 {{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . | humanize }}</a>
 								{{ end }}
               </li>


### PR DESCRIPTION
With this PR, the config option `multi_author` is not needed anymore since both atomic strings as well as string arrays are supported "side-by-side" in the `author` frontmatter param.