### PR TITLE
Fix Google Maps JS snippet inclusion

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
 	{{- partialCached "preloader.html" . -}}
 	{{- partial "header.html" . -}}
 	{{- block "main" . }}{{- end }}
-	{{- partialCached "footer.html" . -}}
+	{{- partial "footer.html" . -}}
 </body>
 
 </html>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,9 +16,9 @@
 </footer>
 
 <!-- Google Map API -->
-{{ if eq .Permalink ("contact/" | absURL) }}
 {{ if site.Params.gmap.enable }}
-<script defer src="https://maps.googleapis.com/maps/api/js?key={{site.Params.gmap.gmap_api}}&libraries=places"></script>
+{{ if ("contact/" | relLangURL | eq .RelPermalink) }}
+<script defer src="https://maps.googleapis.com/maps/api/js?key={{ site.Params.gmap.gmap_api }}&libraries=places"></script>
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
and avert use of [`partialCached`](https://gohugo.io/functions/partialcached/) for `footer.html` since it breaks the conditional logic in there (because with `partialCached` the partial is only executed _once_ per site).