### PR TITLE
Refactor shortcodes and partials to ignore terminating newline

### DIFF
--- a/layouts/partials/cloak_email.html
+++ b/layouts/partials/cloak_email.html
@@ -1,5 +1,6 @@
-{{/* Cloak an e-mail address (first argument) */}}
+{{/* Cloak an e-mail address (first argument) */ -}}
 {{- $address_parts := split . "@" -}}
 {{- $user := index $address_parts 0 -}}
 {{- $domain := index $address_parts 1 -}}
-<span class="cloaked-e-mail" data-user="{{ range $index := seq (sub (len $user) 1) 0}}{{ substr $user $index 1}}{{ end }}" data-domain="{{ range $index := seq (sub (len $domain) 1) 0}}{{ substr $domain $index 1}}{{ end }}"></span>
+<span class="cloaked-e-mail" data-user="{{ range $index := seq (sub (len $user) 1) 0 }}{{ substr $user $index 1 }}{{ end }}" data-domain="{{ range $index := seq (sub (len $domain) 1) 0 }}{{ substr $domain $index 1 }}{{ end }}"></span>
+{{- /* Dummy comment to strip trailing newline */ -}}

--- a/layouts/partials/date_i18n.html
+++ b/layouts/partials/date_i18n.html
@@ -1,1 +1,3 @@
-{{/* Localize .PublishDate; returns the standard English "January 2, 2006" format, if no specific override is defined */}}{{ $lang := $.Site.Language.Lang }}{{ $date := .PublishDate }}{{ if eq $lang "de" }}{{ $date.Day }}. {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else if in (slice "fr" "it") $lang }}{{ $date.Day }} {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else }}{{ $date.Format "January 2, 2006" }}{{ end }}
+{{/* Localize .PublishDate; returns the standard English "January 2, 2006" format, if no language-specific override exists */ -}}
+{{ $lang := $.Page.Language.Lang }}{{ $date := .PublishDate }}{{ if eq $lang "de" }}{{ $date.Day }}. {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else if in (slice "fr" "it") $lang }}{{ $date.Day }} {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else }}{{ $date.Format "January 2, 2006" }}{{ end }}
+{{- /* Dummy comment to strip trailing newline */ -}}

--- a/layouts/shortcodes/cloak_email.html
+++ b/layouts/shortcodes/cloak_email.html
@@ -2,8 +2,9 @@
 Cloak an e-mail address
 
 Usage: {{< cloak_email EMAIL >}}
-*/}}-->
+*/}} -->
 {{- $address_parts := split (.Get 0) "@" -}}
 {{- $user := index $address_parts 0 -}}
 {{- $domain := index $address_parts 1 -}}
-<span class="cloaked-e-mail" data-user="{{ range $index := seq (sub (len $user) 1) 0}}{{ substr $user $index 1}}{{ end }}" data-domain="{{ range $index := seq (sub (len $domain) 1) 0}}{{ substr $domain $index 1}}{{ end }}"></span>
+<span class="cloaked-e-mail" data-user="{{ range $index := seq (sub (len $user) 1) 0 }}{{ substr $user $index 1 }}{{ end }}" data-domain="{{ range $index := seq (sub (len $domain) 1) 0 }}{{ substr $domain $index 1 }}{{ end }}"></span>
+{{- /* Dummy comment to strip trailing newline */ -}}

--- a/layouts/shortcodes/date_i18n.html
+++ b/layouts/shortcodes/date_i18n.html
@@ -2,4 +2,6 @@
 Localize a date string like "2006-01-02"; returns the standard English "January 2, 2006" format, if no language-specific override is defined in the shortcode's source
 
 Usage: {{< date_i18n DATE >}}
-*/}}-->{{ $lang := $.Site.Language.Lang }}{{ $date := time (.Get 0) }}{{ if eq $lang "de" }}{{ $date.Day }}. {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else if in (slice "fr" "it") $lang }}{{ $date.Day }} {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else }}{{ $date.Format "January 2, 2006" }}{{ end }}
+*/}} -->
+{{- $lang := $.Site.Language.Lang }}{{ $date := time (.Get 0) }}{{ if eq $lang "de" }}{{ $date.Day }}. {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else if in (slice "fr" "it") $lang }}{{ $date.Day }} {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else }}{{ $date.Format "January 2, 2006" }}{{ end -}}
+{{- /* Dummy comment to strip trailing newline */ -}}


### PR DESCRIPTION
This ensures that shortcodes and corresponding partials are agnostic to the newline character terminating a file, i.e. allows the files to be [POSIX-compliant](https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline).