### PR TITLE
Avoid absolute URLs

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,11 +13,11 @@
         {{ range $paginator.Pages }}
         <div class="post">
           <div class="post-media post-thumb">
-            <a href="{{ .Permalink }}">
+            <a href="{{ .RelPermalink }}">
               <img src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
             </a>
           </div>
-          <h3 class="post-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
+          <h3 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
           <div class="post-meta">
             <ul>
               <li><i class="ion-calendar"></i> {{ partial "date_i18n.html" . }}</li>
@@ -33,7 +33,7 @@
           </div>
           <div class="post-content">
             <p>{{ .Summary }}</p>
-            <a href="{{ .Permalink }}" class="btn btn-main">{{ i18n "read_more" }}</a>
+            <a href="{{ .RelPermalink }}" class="btn btn-main">{{ i18n "read_more" }}</a>
           </div>
         </div>
         {{ end }}

--- a/layouts/_default/service.html
+++ b/layouts/_default/service.html
@@ -12,7 +12,7 @@
         <p class="mt-30">{{ .content | markdownify }}</p>
       </div>
       <div class="col-md-6">
-        <img class="img-responsive" src="{{ .image | absURL }}">
+        <img class="img-responsive" src="{{ .image | relURL }}">
       </div>
     </div>
   </div>

--- a/layouts/author/single.html
+++ b/layouts/author/single.html
@@ -47,11 +47,11 @@
 			<div class="col-md-6">
 				<div class="post">
 					<div class="post-thumb">
-						<a href="{{ .Permalink }}">
+						<a href="{{ .RelPermalink }}">
 							<img class="img-responsive" src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
 						</a>
 					</div>
-					<h3 class="post-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
+					<h3 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
 					<div class="post-meta">
 						<ul>
 							<li><i class="ion-calendar"></i> {{ partial "date_i18n.html" . }}</li>
@@ -67,7 +67,7 @@
 					</div>
 					<div class="post-content">
 						<p>{{ .Summary }}</p>
-						<a href="{{ .Permalink }}" class="btn btn-main">{{ i18n "read_more" }}</a>
+						<a href="{{ .RelPermalink }}" class="btn btn-main">{{ i18n "read_more" }}</a>
 					</div>
 				</div>
 			</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 <!-- banner -->
 {{ with .Params.banner }}
 {{ if .enable }}
-<section class="slider {{if .bg_overlay}}overly{{end}}" style="background-image: url('{{ .bg_image | absURL }}');">
+<section class="slider {{if .bg_overlay}}overly{{end}}" style="background-image: url('{{ .bg_image | relURL }}');">
   <div class="container">
     <div class="row">
       <div class="col-md-12">
@@ -54,7 +54,7 @@
 {{ with .Params.portfolio }}
 {{ if .enable }}
 <!-- portfolio -->
-<section class="feature bg-2" style="background-image: url('{{ .bg_image | absURL}}')">
+<section class="feature bg-2" style="background-image: url('{{ .bg_image | relURL}}')">
   <div class="container">
     <div class="row">
       <div class="col-md-6 col-md-offset-6">

--- a/layouts/partials/cta.html
+++ b/layouts/partials/cta.html
@@ -1,6 +1,6 @@
 {{ with site.GetPage "/" }}
 {{ with .Params.cta }}
-<section class="call-to-action bg-1 section-sm overly" style="background-image: url('{{.bg_image | absURL }}');">
+<section class="call-to-action bg-1 section-sm overly" style="background-image: url('{{.bg_image | relURL }}');">
   <div class="container">
     <div class="row">
       <div class="col-md-12">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -24,12 +24,12 @@
 
 <!-- JS Plugins -->
 {{ range site.Params.plugins.js}}
-<script src="{{ .link | absURL }}" {{.attributes | safeHTMLAttr}}></script>
+<script src="{{ .link | relURL }}" {{.attributes | safeHTMLAttr}}></script>
 {{ end }}
 
 <!-- Main Script -->
 {{ $script := resources.Get "js/script.js" | minify}}
-<script src="{{ $script.Permalink }}"></script>
+<script src="{{ $script.RelPermalink }}"></script>
 
 <!-- cookie -->
 {{ if site.Params.cookies.enable }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,15 +17,15 @@
 
   {{ "<!-- Plugins -->" | safeHTML }}
   {{ range site.Params.plugins.css}}
-  <link rel="stylesheet" href="{{ .link | absURL }}" {{.attributes | safeHTMLAttr}}>
+  <link rel="stylesheet" href="{{ .link | relURL }}" {{.attributes | safeHTMLAttr}}>
   {{ end }}
 
   {{ "<!-- Main Stylesheet -->" | safeHTML }}
   {{ $styles := resources.Get "scss/style.scss" | toCSS | minify }}
-  <link rel="stylesheet" href="{{ $styles.Permalink }}" media="screen">
+  <link rel="stylesheet" href="{{ $styles.RelPermalink }}" media="screen">
 
   {{ "<!--Favicon-->" | safeHTML }}
-  <link rel="shortcut icon" href="{{ `images/favicon.png` | absURL }}" type="image/x-icon">
-  <link rel="icon" href="{{ `images/favicon.png` | absURL }}" type="image/x-icon">
+  <link rel="shortcut icon" href="{{ `images/favicon.png` | relURL }}" type="image/x-icon">
+  <link rel="icon" href="{{ `images/favicon.png` | relURL }}" type="image/x-icon">
 
 </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -48,11 +48,11 @@
                   {{ if eq $translation.Lang .Lang }}
                   {{ $selected := false }}
                   {{ if eq $pageLang .Lang}}
-                  <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}" selected>
+                  <option id="{{ $translation.Language }}" value="{{ $translation.RelPermalink }}" selected>
                     {{ .LanguageName }}
                   </option>
                   {{ else }}
-                  <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}">{{ .LanguageName }}
+                  <option id="{{ $translation.Language }}" value="{{ $translation.RelPermalink }}">{{ .LanguageName }}
                   </option>
                   {{ end }}
                   {{ end }}

--- a/layouts/partials/page-title.html
+++ b/layouts/partials/page-title.html
@@ -1,4 +1,4 @@
-<section class="page-title bg-2" style="background-image: url('{{.Params.Bg_image | absURL}}');">
+<section class="page-title bg-2" style="background-image: url('{{.Params.Bg_image | relURL}}');">
   <div class="container">
     <div class="row">
       <div class="col-md-12">

--- a/layouts/partials/preloader.html
+++ b/layouts/partials/preloader.html
@@ -2,7 +2,7 @@
 {{ "<!-- preloader start -->" | safeHTML }}
 <div class="preloader">
   {{ if ne site.Params.preloader.preloader "" }}
-  <img src="{{ site.Params.preloader.preloader | absURL }} " alt="preloader">
+  <img src="{{ site.Params.preloader.preloader | relURL }} " alt="preloader">
   {{ end }}
 </div>
 {{ "<!-- preloader end -->" | safeHTML }}

--- a/layouts/partials/widgets/recent_posts.html
+++ b/layouts/partials/widgets/recent_posts.html
@@ -2,11 +2,11 @@
     <h4 class="widget-title">{{ i18n "latest_posts" }}</h4>
     {{ range first 4 (where site.Pages "Type" "post") }}
     <div class="media">
-      <a class="pull-left" href="{{ .Permalink }}">
+      <a class="pull-left" href="{{ .RelPermalink }}">
         <img class="media-object" src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
       </a>
       <div class="media-body">
-        <h4 class="media-heading"><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
+        <h4 class="media-heading"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h4>
         <p>{{ .Summary | truncate 50 }}</p>
       </div>
     </div>

--- a/layouts/project/list.html
+++ b/layouts/project/list.html
@@ -33,7 +33,7 @@
               <div class="portfolio-hover">
                 <div class="portfolio-content">
                   <a href="{{ .Params.Image | relURL }}" class="portfolio-popup"><i class="icon ion-search"></i></a>
-                  <a class="h3" href="{{ .Permalink }}">{{ .Title }}</a>
+                  <a class="h3" href="{{ .RelPermalink }}">{{ .Title }}</a>
                   <p>{{ .Params.Description }}</p>
                 </div>
               </div>


### PR DESCRIPTION
Replace `absURL` -> `relURL` and `.Permalink` -> `.RelPermalink` in all remaining places to make the theme more portable, cf. #118