### PR TITLE
Improve Open Graph / Twitter Card image tags

### DIFF
--- a/exampleSite/.forestry/front_matter/templates/author.yml
+++ b/exampleSite/.forestry/front_matter/templates/author.yml
@@ -5,11 +5,14 @@ fields:
 - type: text
   name: title
   label: title
-- name: image
-  type: file
-  config:
-    maxSize: 250
-  label: image
+- type: image_gallery
+  name: images
+  label: post image(s)
+  description: Author image(s); the 1st image is visible, the others are only used for Open Graph metadata
+- type: file
+  name: bg_image
+  label: background image
+  description: Page header background image
 - type: text
   name: email
   label: email

--- a/exampleSite/.forestry/front_matter/templates/post.yml
+++ b/exampleSite/.forestry/front_matter/templates/post.yml
@@ -8,13 +8,14 @@ fields:
 - type: datetime
   name: date
   label: date
+- type: image_gallery
+  name: images
+  label: post image(s)
+  description: Post image(s); the 1st image is visible, the others are only used for Open Graph metadata
 - type: file
   name: bg_image
-  label: bg image
-  description: page header background image
-- type: file
-  name: image
-  label: image
+  label: background image
+  description: Page header background image
 - type: text
   name: author
   label: author

--- a/exampleSite/.forestry/front_matter/templates/project.yml
+++ b/exampleSite/.forestry/front_matter/templates/project.yml
@@ -9,13 +9,14 @@ fields:
   name: description
   label: description
   description: this is meta description
-- type: file
-  name: image
-  label: image
+- type: image_gallery
+  name: images
+  label: post image(s)
+  description: Project image(s); the 1st image is visible, the others are only used for Open Graph metadata
 - type: file
   name: bg_image
-  label: bg image
-  description: page header background image
+  label: background image
+  description: Page header background image
 - type: text
   name: category
   label: category

--- a/exampleSite/content/english/blog/blog-post-1.md
+++ b/exampleSite/content/english/blog/blog-post-1.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-1.jpg"
+images: [ "images/blog/blog-post-1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Company News"]
 tags: ["Advice","Technology"]

--- a/exampleSite/content/english/blog/blog-post-2.md
+++ b/exampleSite/content/english/blog/blog-post-2.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: [ "Mark Dinn", "John Doe" ]
-image : "images/blog/blog-post-2.jpg"
+images: [ "images/blog/blog-post-2.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Artificial Intelligence"]
 tags: ["Advice","Retro"]

--- a/exampleSite/content/english/blog/blog-post-3.md
+++ b/exampleSite/content/english/blog/blog-post-3.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-3.jpg"
+images: [ "images/blog/blog-post-3.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Legacy Support"]
 tags: ["Android","Retro"]

--- a/exampleSite/content/english/blog/blog-post-4.md
+++ b/exampleSite/content/english/blog/blog-post-4.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-4.jpg"
+images: [ "images/blog/blog-post-4.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Legacy Support"]
 tags: ["Mechine","Retro"]

--- a/exampleSite/content/english/blog/blog-post-5.md
+++ b/exampleSite/content/english/blog/blog-post-5.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-5.jpg"
+images: [ "images/blog/blog-post-5.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Artificial Intelligence"]
 tags: ["Advice","AI"]

--- a/exampleSite/content/english/blog/blog-post-6.md
+++ b/exampleSite/content/english/blog/blog-post-6.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-6.jpg"
+images: [ "images/blog/blog-post-6.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Company News"]
 tags: ["News","Retro","AI","Company"]

--- a/exampleSite/content/english/blog/date-i18n.md
+++ b/exampleSite/content/english/blog/date-i18n.md
@@ -2,7 +2,7 @@
 title: "Pretty-print dates"
 date: 2021-04-01T00:00:00+01:00
 author: John Doe
-image : "images/blog/blog-post-1.jpg"
+images: [ "images/blog/blog-post-1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Technical Assistance"]
 tags: ["How to", "Technology"]

--- a/exampleSite/content/english/project/rio-furniture-1.md
+++ b/exampleSite/content/english/project/rio-furniture-1.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work1.jpg"
+images: [ "images/portfolio/work1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "UI/UX Design"
 information:

--- a/exampleSite/content/english/project/rio-furniture-2.md
+++ b/exampleSite/content/english/project/rio-furniture-2.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work2.jpg"
+images: [ "images/portfolio/work2.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Illustration"
 information:

--- a/exampleSite/content/english/project/rio-furniture-3.md
+++ b/exampleSite/content/english/project/rio-furniture-3.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work3.jpg"
+images: [ "images/portfolio/work3.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Video"
 information:

--- a/exampleSite/content/english/project/rio-furniture-4.md
+++ b/exampleSite/content/english/project/rio-furniture-4.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work4.jpg"
+images: [ "images/portfolio/work4.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "UI/UX Design"
 information:

--- a/exampleSite/content/english/project/rio-furniture-5.md
+++ b/exampleSite/content/english/project/rio-furniture-5.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work5.jpg"
+images: [ "images/portfolio/work5.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Illustration"
 information:

--- a/exampleSite/content/english/project/rio-furniture-6.md
+++ b/exampleSite/content/english/project/rio-furniture-6.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work6.jpg"
+images: [ "images/portfolio/work6.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Video"
 information:

--- a/exampleSite/content/french/blog/blog-post-1.md
+++ b/exampleSite/content/french/blog/blog-post-1.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-1.jpg"
+images: [ "images/blog/blog-post-1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Company News"]
 tags: ["Advice","Technology"]

--- a/exampleSite/content/french/blog/blog-post-2.md
+++ b/exampleSite/content/french/blog/blog-post-2.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-2.jpg"
+images: [ "images/blog/blog-post-2.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Artificial Intelligence"]
 tags: ["Advice","Retro"]

--- a/exampleSite/content/french/blog/blog-post-3.md
+++ b/exampleSite/content/french/blog/blog-post-3.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-3.jpg"
+images: [ "images/blog/blog-post-3.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Legacy Support"]
 tags: ["Android","Retro"]

--- a/exampleSite/content/french/blog/blog-post-4.md
+++ b/exampleSite/content/french/blog/blog-post-4.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-4.jpg"
+images: [ "images/blog/blog-post-4.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Legacy Support"]
 tags: ["Mechine","Retro"]

--- a/exampleSite/content/french/blog/blog-post-5.md
+++ b/exampleSite/content/french/blog/blog-post-5.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-5.jpg"
+images: [ "images/blog/blog-post-5.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Artificial Intelligence"]
 tags: ["Advice","AI"]

--- a/exampleSite/content/french/blog/blog-post-6.md
+++ b/exampleSite/content/french/blog/blog-post-6.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-6.jpg"
+images: [ "images/blog/blog-post-6.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Company News"]
 tags: ["News","Retro","AI","Company"]

--- a/exampleSite/content/french/blog/date-i18n.md
+++ b/exampleSite/content/french/blog/date-i18n.md
@@ -2,7 +2,7 @@
 title: "Pretty-print dates"
 date: 2021-04-01T00:00:00+01:00
 author: John Doe
-image : "images/blog/blog-post-1.jpg"
+images: [ "images/blog/blog-post-1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Technical Assistance"]
 tags: ["How to", "Technology"]

--- a/exampleSite/content/french/project/rio-furniture-1.md
+++ b/exampleSite/content/french/project/rio-furniture-1.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work1.jpg"
+images: [ "images/portfolio/work1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "UI/UX Design"
 information:

--- a/exampleSite/content/french/project/rio-furniture-2.md
+++ b/exampleSite/content/french/project/rio-furniture-2.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work2.jpg"
+images: [ "images/portfolio/work2.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Illustration"
 information:

--- a/exampleSite/content/french/project/rio-furniture-3.md
+++ b/exampleSite/content/french/project/rio-furniture-3.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work3.jpg"
+images: [ "images/portfolio/work3.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Video"
 information:

--- a/exampleSite/content/french/project/rio-furniture-4.md
+++ b/exampleSite/content/french/project/rio-furniture-4.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work4.jpg"
+images: [ "images/portfolio/work4.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "UI/UX Design"
 information:

--- a/exampleSite/content/french/project/rio-furniture-5.md
+++ b/exampleSite/content/french/project/rio-furniture-5.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work5.jpg"
+images: [ "images/portfolio/work5.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Illustration"
 information:

--- a/exampleSite/content/french/project/rio-furniture-6.md
+++ b/exampleSite/content/french/project/rio-furniture-6.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work6.jpg"
+images: [ "images/portfolio/work6.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Video"
 information:

--- a/exampleSite/content/german/blog/blog-post-1.md
+++ b/exampleSite/content/german/blog/blog-post-1.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-1.jpg"
+images: [ "images/blog/blog-post-1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Company News"]
 tags: ["Advice","Technology"]

--- a/exampleSite/content/german/blog/blog-post-2.md
+++ b/exampleSite/content/german/blog/blog-post-2.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-2.jpg"
+images: [ "images/blog/blog-post-2.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Artificial Intelligence"]
 tags: ["Advice","Retro"]

--- a/exampleSite/content/german/blog/blog-post-3.md
+++ b/exampleSite/content/german/blog/blog-post-3.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-3.jpg"
+images: [ "images/blog/blog-post-3.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Legacy Support"]
 tags: ["Android","Retro"]

--- a/exampleSite/content/german/blog/blog-post-4.md
+++ b/exampleSite/content/german/blog/blog-post-4.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-4.jpg"
+images: [ "images/blog/blog-post-4.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Legacy Support"]
 tags: ["Mechine","Retro"]

--- a/exampleSite/content/german/blog/blog-post-5.md
+++ b/exampleSite/content/german/blog/blog-post-5.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-5.jpg"
+images: [ "images/blog/blog-post-5.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Artificial Intelligence"]
 tags: ["Advice","AI"]

--- a/exampleSite/content/german/blog/blog-post-6.md
+++ b/exampleSite/content/german/blog/blog-post-6.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-6.jpg"
+images: [ "images/blog/blog-post-6.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Company News"]
 tags: ["News","Retro","AI","Company"]

--- a/exampleSite/content/german/blog/date-i18n.md
+++ b/exampleSite/content/german/blog/date-i18n.md
@@ -2,7 +2,7 @@
 title: "Pretty-print dates"
 date: 2021-04-01T00:00:00+01:00
 author: John Doe
-image : "images/blog/blog-post-1.jpg"
+images: [ "images/blog/blog-post-1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Technical Assistance"]
 tags: ["How to", "Technology"]

--- a/exampleSite/content/german/project/rio-furniture-1.md
+++ b/exampleSite/content/german/project/rio-furniture-1.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work1.jpg"
+images: [ "images/portfolio/work1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "UI/UX Design"
 information:

--- a/exampleSite/content/german/project/rio-furniture-2.md
+++ b/exampleSite/content/german/project/rio-furniture-2.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work2.jpg"
+images: [ "images/portfolio/work2.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Illustration"
 information:

--- a/exampleSite/content/german/project/rio-furniture-3.md
+++ b/exampleSite/content/german/project/rio-furniture-3.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work3.jpg"
+images: [ "images/portfolio/work3.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Video"
 information:

--- a/exampleSite/content/german/project/rio-furniture-4.md
+++ b/exampleSite/content/german/project/rio-furniture-4.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work4.jpg"
+images: [ "images/portfolio/work4.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "UI/UX Design"
 information:

--- a/exampleSite/content/german/project/rio-furniture-5.md
+++ b/exampleSite/content/german/project/rio-furniture-5.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work5.jpg"
+images: [ "images/portfolio/work5.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Illustration"
 information:

--- a/exampleSite/content/german/project/rio-furniture-6.md
+++ b/exampleSite/content/german/project/rio-furniture-6.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work6.jpg"
+images: [ "images/portfolio/work6.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Video"
 information:

--- a/exampleSite/content/italian/blog/blog-post-1.md
+++ b/exampleSite/content/italian/blog/blog-post-1.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-1.jpg"
+images: [ "images/blog/blog-post-1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Company News"]
 tags: ["Advice","Technology"]

--- a/exampleSite/content/italian/blog/blog-post-2.md
+++ b/exampleSite/content/italian/blog/blog-post-2.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-2.jpg"
+images: [ "images/blog/blog-post-2.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Artificial Intelligence"]
 tags: ["Advice","Retro"]

--- a/exampleSite/content/italian/blog/blog-post-3.md
+++ b/exampleSite/content/italian/blog/blog-post-3.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-3.jpg"
+images: [ "images/blog/blog-post-3.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Legacy Support"]
 tags: ["Android","Retro"]

--- a/exampleSite/content/italian/blog/blog-post-4.md
+++ b/exampleSite/content/italian/blog/blog-post-4.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-4.jpg"
+images: [ "images/blog/blog-post-4.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Legacy Support"]
 tags: ["Mechine","Retro"]

--- a/exampleSite/content/italian/blog/blog-post-5.md
+++ b/exampleSite/content/italian/blog/blog-post-5.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: Mark Dinn
-image : "images/blog/blog-post-5.jpg"
+images: [ "images/blog/blog-post-5.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Artificial Intelligence"]
 tags: ["Advice","AI"]

--- a/exampleSite/content/italian/blog/blog-post-6.md
+++ b/exampleSite/content/italian/blog/blog-post-6.md
@@ -2,7 +2,7 @@
 title: "How To Wear Bright Shoes"
 date: 2018-09-24T11:07:10+06:00
 author: John Doe
-image : "images/blog/blog-post-6.jpg"
+images: [ "images/blog/blog-post-6.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Company News"]
 tags: ["News","Retro","AI","Company"]

--- a/exampleSite/content/italian/blog/date-i18n.md
+++ b/exampleSite/content/italian/blog/date-i18n.md
@@ -2,7 +2,7 @@
 title: "Pretty-print dates"
 date: 2021-04-01T00:00:00+01:00
 author: John Doe
-image : "images/blog/blog-post-1.jpg"
+images: [ "images/blog/blog-post-1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 categories: ["Technical Assistance"]
 tags: ["How to", "Technology"]

--- a/exampleSite/content/italian/project/rio-furniture-1.md
+++ b/exampleSite/content/italian/project/rio-furniture-1.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work1.jpg"
+images: [ "images/portfolio/work1.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "UI/UX Design"
 information:

--- a/exampleSite/content/italian/project/rio-furniture-2.md
+++ b/exampleSite/content/italian/project/rio-furniture-2.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work2.jpg"
+images: [ "images/portfolio/work2.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Illustration"
 information:

--- a/exampleSite/content/italian/project/rio-furniture-3.md
+++ b/exampleSite/content/italian/project/rio-furniture-3.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work3.jpg"
+images: [ "images/portfolio/work3.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Video"
 information:

--- a/exampleSite/content/italian/project/rio-furniture-4.md
+++ b/exampleSite/content/italian/project/rio-furniture-4.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work4.jpg"
+images: [ "images/portfolio/work4.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "UI/UX Design"
 information:

--- a/exampleSite/content/italian/project/rio-furniture-5.md
+++ b/exampleSite/content/italian/project/rio-furniture-5.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work5.jpg"
+images: [ "images/portfolio/work5.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Illustration"
 information:

--- a/exampleSite/content/italian/project/rio-furniture-6.md
+++ b/exampleSite/content/italian/project/rio-furniture-6.md
@@ -2,7 +2,7 @@
 title: "Rio Furniture"
 description: "this is meta description"
 draft: false
-image : "images/portfolio/work6.jpg"
+images: [ "images/portfolio/work6.jpg" ]
 bg_image: "images/feature-bg.jpg"
 category: "Video"
 information:

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -14,7 +14,9 @@
         <div class="post">
           <div class="post-media post-thumb">
             <a href="{{ .RelPermalink }}">
-              <img src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
+              {{ if isset .Params "images" }}
+              <img src="{{ index .Params.images 0 | relURL }}" alt="{{ .Title }}">
+              {{ end }}
             </a>
           </div>
           <h3 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,7 +25,9 @@
             </ul>
 					</div>
 					<div class="post-thumb">
-						<img class="img-responsive" src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
+            {{ if isset .Params "images" }}
+						<img class="img-responsive" src="{{ index .Params.images 0 | relURL }}" alt="{{ .Title }}">
+            {{ end }}
 					</div>
 					<div class="post-content post-excerpt">
 						{{ .Content }}

--- a/layouts/author/single.html
+++ b/layouts/author/single.html
@@ -48,7 +48,9 @@
 				<div class="post">
 					<div class="post-thumb">
 						<a href="{{ .RelPermalink }}">
-							<img class="img-responsive" src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
+              {{ if isset .Params "images" }}
+							<img class="img-responsive" src="{{ index .Params.images 0 | relURL }}" alt="{{ .Title }}">
+              {{ end }}
 						</a>
 					</div>
 					<h3 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,9 +8,6 @@
   {{ with site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
   {{ hugo.Generator }}
 
-  {{ with .Params.image }}
-  <meta property="og:image" content="{{ . | absURL }}" />
-  {{ end }}
   {{ template "_internal/opengraph.html" . }}
   {{ template "_internal/twitter_cards.html" . }}
   {{ template "_internal/google_analytics.html" . }}

--- a/layouts/partials/widgets/recent_posts.html
+++ b/layouts/partials/widgets/recent_posts.html
@@ -3,7 +3,9 @@
     {{ range first 4 (where site.Pages "Type" "post") }}
     <div class="media">
       <a class="pull-left" href="{{ .RelPermalink }}">
-        <img class="media-object" src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
+        {{ if isset .Params "images" }}
+        <img class="media-object" src="{{ index .Params.images 0 | relURL }}" alt="{{ .Title }}">
+        {{ end }}
       </a>
       <div class="media-body">
         <h4 class="media-heading"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h4>

--- a/layouts/project/list.html
+++ b/layouts/project/list.html
@@ -28,16 +28,18 @@
           </div>
           <div class="row shuffle-wrapper">
             {{ range .Data.Pages }}
+            {{ if isset .Params "images" }}
             <div class="col-md-4 portfolio-item shuffle-item" data-groups="[&quot;{{ .Params.Category | urlize }}&quot;]">
-              <img src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
+              <img src="{{ index .Params.images 0 | relURL }}" alt="{{ .Title }}">
               <div class="portfolio-hover">
                 <div class="portfolio-content">
-                  <a href="{{ .Params.Image | relURL }}" class="portfolio-popup"><i class="icon ion-search"></i></a>
+                  <a href="{{ index .Params.images 0 | relURL }}" class="portfolio-popup"><i class="icon ion-search"></i></a>
                   <a class="h3" href="{{ .RelPermalink }}">{{ .Title }}</a>
                   <p>{{ .Params.Description }}</p>
                 </div>
               </div>
             </div>
+            {{ end }}
             {{ end }}
           </div>
         </div>

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -8,7 +8,9 @@
   <div class="container">
     <div class="row">
       <div class="col-md-8">
-        <img class="img-responsive w-100" src="{{ .Params.Image | relURL }}" alt="">
+        {{ if isset .Params "images" }}
+        <img class="img-responsive w-100" src="{{ index .Params.images 0 | relURL }}" alt="">
+        {{ end }}
       </div>
       <div class="col-md-4">
         <div class="project-details">


### PR DESCRIPTION
Since we use Hugo's internal [Open Graph](https://gohugo.io/templates/internal/#open-graph) and [Twitter Card](https://gohugo.io/templates/internal/#twitter-cards) templates, we should stick to the **`images`** key (array) in front matter instead of the `image` key (atomic). I've changed all relevant pieces to accomplish that.

Now the individual blog posts as well as the project pages have their own open graph / twitter card image metadata tag generated as one would expect (before it was always the site logo). The site logo is still used as a global fallback (configured in `config.toml` via `params.images`) when a page has no dedicated `images` key set.