### PR TITLE
Add support for counter.dev analytics

### DIFF
--- a/assets/js/counter.min.js
+++ b/assets/js/counter.min.js
@@ -1,0 +1,1 @@
+if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.dev/track?"+new URLSearchParams({referrer:document.referrer,screen:screen.width+"x"+screen.height,user:"{{ . }}",utcoffset:"0"}))};sessionStorage.setItem("_swa","1");

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -97,6 +97,14 @@ enable = true
 expire_days = 2
 
 
+################################# counter.dev analytics #######################
+# This is a [privacy-friendly alternative](https://counter.dev/privacy.html) to Google Analytics & Co.
+[params.counter]
+enable = true
+# counter.dev username, see https://counter.dev/setup.html
+username = ""
+
+
 ################################# Social Media ################################
 [[params.social]]
 icon = "ion-social-googleplus-outline" #ionicon pack v2 : https://ionicons.com/v2/

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,6 +15,16 @@
   {{ template "_internal/twitter_cards.html" . }}
   {{ template "_internal/google_analytics.html" . }}
 
+  {{- with site.Params.counter -}}
+  {{ if .enable -}}
+  {{ with .username -}}
+  {{ "<!-- counter.dev analytics -->" | safeHTML }}
+  {{ $counterjs := resources.Get "js/counter.min.js" | resources.ExecuteAsTemplate "js/counter.min.js" . -}}
+  <script src="{{ $counterjs.RelPermalink }}"></script>
+  {{- end }}
+  {{- end }}
+  {{- end }}
+
   {{ "<!-- Plugins -->" | safeHTML }}
   {{ range site.Params.plugins.css}}
   <link rel="stylesheet" href="{{ .link | relURL }}" {{.attributes | safeHTMLAttr}}>


### PR DESCRIPTION
[counter.dev](https://counter.dev/) offers a [privacy-friendly](https://counter.dev/privacy.html) and leightweight alternative to Google Analytics that probably satisfies most basic needs. AFAIC it doesn't need any kind of privacy notice / cookie banner in EU jurisdiction (GDPR) since it doesn't collect any personal data from website visitors and doesn't rely on cookies at all. counter.dev is free to use, open source and lives from donations.