### PR TITLE
Center `.bg-1` background images

### DIFF
--- a/assets/scss/templates/_backgrounds.scss
+++ b/assets/scss/templates/_backgrounds.scss
@@ -1,5 +1,6 @@
 .bg-1 {
 	background-size: cover;
+  background-position: center center;
 	background-repeat: no-repeat;
 	background-attachment: fixed;
 

--- a/assets/scss/templates/_backgrounds.scss
+++ b/assets/scss/templates/_backgrounds.scss
@@ -1,19 +1,19 @@
 .bg-1 {
-	background-size: cover;
+  background-size: cover;
   background-position: center center;
-	background-repeat: no-repeat;
-	background-attachment: fixed;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
 
-	@include tablet {
-		background-attachment: scroll;
-	}
+  @include tablet {
+    background-attachment: scroll;
+  }
 }
 
 .bg-2 {
-	background-size: cover;
-	background-attachment: fixed;
+  background-size: cover;
+  background-attachment: fixed;
 
-	@include tablet {
-		background-attachment: scroll;
-	}
+  @include tablet {
+    background-attachment: scroll;
+  }
 }


### PR DESCRIPTION
This centers background images of class `bg-1` horizontally and vertically, which makes them less sensitive to viewport width (better responsive design) and probably is what most users expect.