### PR TITLE
Tweak Open Graph and Twitter Card metadata generation

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,23 +2,39 @@
   <meta charset="utf-8">
   <title>{{ with .Title }}{{ . }}{{ else }}{{ site.Title }}{{ end }}</title>
 
-  {{ "<!-- Mobile responsive meta -->" | safeHTML }}
+  {{ "<!-- Mobile responsive metadata -->" | safeHTML }}
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <meta name="description" content="{{ with .Params.Description }}{{ . }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}">
   {{ with site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
   {{ hugo.Generator }}
 
-  {{ with .Params.image }}
-  <meta property="og:image" content="{{ . | absURL }}" />
-  <meta name="twitter:image" content="{{ . | absURL }}"/>
-  {{ else }}
-  {{ with site.Params.image }}
-  <meta property="og:image" content="{{ . | absURL }}" />
-  <meta name="twitter:image" content="{{ . | absURL }}"/>
-  {{ end }}
-  {{ end }}
+  {{ "<!-- Open Graph image and Twitter Card metadata -->" | safeHTML }}
+  {{ $image_path := .Params.image | default site.Params.image -}}
+  {{ $image_path_local :=  printf "static/%s" $image_path -}}
+  {{ $image_ext := trim (path.Ext $image_path | lower) "." -}}
+  {{ if fileExists $image_path_local -}}
+    <meta property="og:image" content="{{ $image_path | absURL }}" />
+    {{/* If not SVG, read image aspect ratio and define Twitter Card and Open Graph width and height  */ -}}
+    {{ if ne $image_ext "svg" -}}
+      {{ with (imageConfig $image_path_local) -}}
+      {{ if (and (gt .Width 144) (gt .Height 144)) -}}
+        <meta name="twitter:image" content="{{ $image_path | absURL }}"/>
+        <meta name="twitter:card" content="summary{{ if (and (gt .Width 300) (gt .Height 157) (not (eq .Width .Height))) }}_large_image{{ end }}">
+      {{ end -}}
+      <meta property="og:image:width" content="{{ .Width }}">
+      <meta property="og:image:height" content="{{ .Height }}">
+      {{ end -}}
+    {{ end -}}
+    <meta property="og:image:type" content="image/{{ if eq $image_ext "svg" }}svg+xml{{ else }}{{ replaceRE "^jpg$" "jpeg" $image_ext }}{{ end }}">
+  {{ end -}}
+  <meta name="twitter:title" content="{{ .Title }}"/>
+  <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
+  {{ with site.Social.twitter -}}<meta name="twitter:site" content="@{{ . }}"/>{{ end -}}
+  {{ range site.Authors }}
+    {{ with .twitter -}}<meta name="twitter:creator" content="@{{ . }}"/>{{ end -}}
+  {{ end -}}
+
   {{ template "_internal/opengraph.html" . }}
-  {{ template "_internal/twitter_cards.html" . }}
   {{ template "_internal/google_analytics.html" . }}
 
   {{- with site.Params.counter -}}


### PR DESCRIPTION
- Don't use Hugo's [internal Twitter Card template](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/twitter_cards.html) since the `twitter:card` tag is basically hardcoded there.

- Instead introduce our own tag generation logic that is based on the actual image dimensions (if not SVG) and respects the minimum dimensions for Twitters [Summary Card](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary) and [Summary Card with Large Image](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image). If the image is square or its dimensions are below 300x157 (but >= 144x144), a _Summary Card_ will be generated, otherwise a _Summary Card with Large Image_ (or nothing in case image is of type SVG or below 144x144).

- Additionally generate `og:image:width`, `og:image:height` and `og:image:type`.