### PR TITLE
Improve templates

### DIFF
--- a/layouts/_default/about.html
+++ b/layouts/_default/about.html
@@ -13,10 +13,10 @@
         </div>
       </div>
       <div class="col-md-6">
-        <h2 class="mt-40">{{ .title | markdownify }}</h2>
-        {{ .content | markdownify }}
-        {{ if .button.enable }}
+        {{ with .title }}<h2 class="mt-40">{{ . | markdownify }}</h2>{{ end }}
+        {{ with .content }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
         {{ with .button }}
+        {{ if .enable }}
         <a href="{{ .link | relURL }}" class="btn btn-small mt-20">{{ .label }}</a>
         {{ end }}
         {{ end }}
@@ -26,9 +26,9 @@
       {{ range .funfacts }}
       <div class="col-md-2">
         <div class="counter-item">
-          <i class="{{ .icon }}"></i>
-          <h4 class="count" data-count="{{ .count }}">0</h4>
-          <span>{{ .name }}</span>
+          {{ with .icon }}<i class="{{ . }}"></i>{{ end }}
+          {{ with .count }}<h4 class="count" data-count="{{ . }}">0</h4>{{ end }}
+          {{ with .name }}<span>{{ . }}</span>{{ end }}
         </div>
       </div>
       {{ end }}
@@ -55,9 +55,9 @@
       {{ range .feature_item }}
       <div class="col-md-4">
         <div class="service-item">
-          <i class="{{ .icon }}"></i>
-          <h4>{{ .name | markdownify }}</h4>
-          <p>{{ .content | markdownify }}</p>
+          {{ with .icon }}<i class="{{ . }}"></i>{{ end }}
+          {{ with .name }}<h4>{{ . | markdownify }}</h4>{{ end }}
+          {{ with .content }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
         </div>
       </div>
       {{ end }}
@@ -78,9 +78,9 @@
             {{ range .Params.funfacts.testimonial_slider }}
             <div>
               <i class="ion-quote"></i>
-              <p>"{{ .content | markdownify }}"</p>
+              {{ with .content }}<p>"{{ . | markdownify }}"</p>{{ end }}
               <div class="user">
-                <img src="{{ .image | relURL }}" alt="client">
+                {{ with .image }}<img src="{{ . | relURL }}" alt="client">{{ end }}
                 <p><span>{{ .name | markdownify }}</span> {{ .designation | markdownify }}</p>
               </div>
             </div>
@@ -104,7 +104,7 @@
           <div class="tab-content">
             {{ range $index, $elements := .tabs }}
             <div id="{{.name | urlize}}" class="tab-pane fade {{ if eq $index 0}} active in {{ end }}">
-              <p>{{ .content | markdownify }}</p>
+              {{ .content | $.Page.RenderString (dict "display" "block") }}
             </div>
             {{ end }}
           </div>

--- a/layouts/_default/faq.html
+++ b/layouts/_default/faq.html
@@ -7,10 +7,10 @@
     <div class="row">
       <div class="col-md-4 sticky-top">
         <h2>{{ .Title }}</h2>
-        <p>{{ .Params.Subtitle | markdownify }}</p>
-        <p>{{ i18n "last_update" }}: {{ .Lastmod.Format "January 2, 2006" }}</p>
+        {{ with .Params.subtitle }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
+        <p>{{ i18n "last_update" }}: {{ partial "date_i18n.html" (dict "date" .Lastmod "lang" .Page.Language.Lang) }}</p>
         <h3>{{ i18n "faq_toc_title" }}</h3>
-        <p>{{ .TableOfContents }}</p>
+        {{ .TableOfContents }}
       </div>
       <div class="col-md-8">
         {{ .Content }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,14 +13,16 @@
         {{ range $paginator.Pages }}
         <div class="post">
           <div class="post-media post-thumb">
+            {{ if isset .Params "image" }}
             <a href="{{ .RelPermalink }}">
-              <img src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
+              <img src="{{ .Params.image | relURL }}" alt="{{ .Title }}">
             </a>
+            {{ end }}
           </div>
           <h3 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
           <div class="post-meta">
             <ul>
-              <li><i class="ion-calendar"></i> {{ partial "date_i18n.html" . }}</li>
+              <li><i class="ion-calendar"></i> {{ partial "date_i18n.html" (dict "date" .PublishDate "lang" .Page.Language.Lang) }}</li>
               <li><i class="ion-android-people"></i>
                 {{ i18n "posted_by" }}
                 {{ $scratch := newScratch }}{{ if reflect.IsSlice .Params.author }}{{ $scratch.Set "authors" .Params.author }}{{ else }}{{ $scratch.Set "authors" (slice .Params.author) }}{{ end }}

--- a/layouts/_default/pricing.html
+++ b/layouts/_default/pricing.html
@@ -12,9 +12,9 @@
       <div class="col-md-4 col-sm-6 col-xs-12">
         <div class="pricing-item text-center">
           <div class="price-title">
-            <h3>{{ .name }}</h3>
-            <strong class="value">{{ .price }}</strong>
-            <p>{{ .content | markdownify }}</p>
+            {{ with .name }}<h3>{{ . | markdownify }}</h3>{{ end }}
+            {{ with .price }}<strong class="value">{{ . }}</strong>{{ end }}
+            {{ with .content }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
           </div>
           <ul>
             {{ range .services }}

--- a/layouts/_default/service.html
+++ b/layouts/_default/service.html
@@ -2,26 +2,28 @@
 
 {{ partial "page-title.html" . }}
 
-{{ if .Params.about.enable }}
 {{ with .Params.about }}
+{{ if .enable }}
 <section class="service-about section">
   <div class="container">
     <div class="row">
       <div class="col-md-6">
-        <h2>{{ .title | markdownify }}</h2>
-        <p class="mt-30">{{ .content | markdownify }}</p>
+        {{ with .title }}<h2>{{ . | markdownify }}</h2>{{ end }}
+        {{ with .content }}<p class="mt-30">{{ . | markdownify }}</p>{{ end }}
       </div>
+      {{ with .image -}}
       <div class="col-md-6">
-        <img class="img-responsive" src="{{ .image | relURL }}">
+        <img class="img-responsive" src="{{ . | relURL }}">
       </div>
+      {{- end }}
     </div>
   </div>
 </section>
 {{ end }}
 {{ end }}
 
-{{ if .Params.featured_service.enable }}
 {{ with .Params.featured_service }}
+{{ if .enable }}
 <section class="service-arrow">
   <div class="container-fluid">
     <div class="row">
@@ -29,8 +31,8 @@
       <div class="col-md-4 bg-primary bg-{{ .color }}">
         <div class="block">
           <i class="{{ .icon }}"></i>
-          <h3>{{ .name | markdownify }}</h3>
-          <p>{{ .content | markdownify }}</p>
+          {{ with .name }}<h3>{{ . | markdownify }}</h3>{{ end }}
+          {{ with .content }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
         </div>
       </div>
       {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,7 +13,7 @@
 					<h2 class="post-title">{{ .Title }}</h2>
 					<div class="post-meta">
 						<ul>
-              <li><i class="ion-calendar"></i> {{ partial "date_i18n.html" . }}</li>
+              <li><i class="ion-calendar"></i> {{ partial "date_i18n.html" (dict "date" .PublishDate "lang" .Page.Language.Lang) }}</li>
               <li><i class="ion-android-people"></i>
                 {{ i18n "posted_by" }}
                 {{ $scratch := newScratch }}{{ if reflect.IsSlice .Params.author }}{{ $scratch.Set "authors" .Params.author }}{{ else }}{{ $scratch.Set "authors" (slice .Params.author) }}{{ end }}
@@ -25,7 +25,9 @@
             </ul>
 					</div>
 					<div class="post-thumb">
-						<img class="img-responsive" src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
+            {{ with .Params.image }}
+						<img class="img-responsive" src="{{ . | relURL }}" alt="{{ $.Title }}">
+            {{ end }}
 					</div>
 					<div class="post-content post-excerpt">
 						{{ .Content }}

--- a/layouts/author/single.html
+++ b/layouts/author/single.html
@@ -47,14 +47,16 @@
 			<div class="col-md-6">
 				<div class="post">
 					<div class="post-thumb">
+            {{ if isset .Params "image" }}
 						<a href="{{ .RelPermalink }}">
-							<img class="img-responsive" src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
+							<img class="img-responsive" src="{{ .Params.image | relURL }}" alt="{{ .Title }}">
 						</a>
+            {{ end }}
 					</div>
 					<h3 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
 					<div class="post-meta">
 						<ul>
-							<li><i class="ion-calendar"></i> {{ partial "date_i18n.html" . }}</li>
+							<li><i class="ion-calendar"></i> {{ partial "date_i18n.html" (dict "date" .PublishDate "lang" .Page.Language.Lang) }}</li>
               <li><i class="ion-android-people"></i>
                 {{ i18n "posted_by" }}
                 {{ $scratch := newScratch }}{{ if reflect.IsSlice .Params.author }}{{ $scratch.Set "authors" .Params.author }}{{ else }}{{ $scratch.Set "authors" (slice .Params.author) }}{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
       <div class="col-md-12">
         <div class="block">
           {{ with .title }}<h1>{{ . | markdownify }}</h1>{{ end }}
-          {{ with .content }}<p>{{ . | markdownify }}</p>{{ end }}
+          {{ with .content }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
           {{ with .button }}
           {{ if .enable }}
           <a href="{{ .link | relLangURL }}" class="btn btn-main animated fadeInUp">{{ .label }}</a>
@@ -34,9 +34,9 @@
         <div class="block">
           <div class="section-title">
             {{ with .title }}<h2>{{ . | markdownify }}</h2>{{ end }}
-            {{ with .description }}<p>{{ . | markdownify }}</p>{{ end }}
+            {{ with .description }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
           </div>
-          {{ with .content }}<p>{{ . | markdownify }}</p>{{ end }}
+          {{ with .content }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
         </div>
       </div>
       <div class="col-md-5 col-sm-12">
@@ -59,7 +59,7 @@
     <div class="row">
       <div class="col-md-6 col-md-offset-6">
         {{ with .title }}<h2 class="section-subtitle">{{ . | markdownify }}</h2>{{ end }}
-        {{ with .content }}<p>{{ . | markdownify }}</p>{{ end }}
+        {{ with .content }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
         {{ with .button }}
         {{ if .enable }}
         <a href="{{ .link | relLangURL }}" class="btn btn-view-works">{{ .label }}</a>
@@ -93,7 +93,7 @@
     <div class="row">
       <div class="section-title text-center">
         {{ with .title }}<h2>{{ . | markdownify }}</h2>{{ end }}
-        {{ with .description }}<p>{{ . | markdownify }}</p>{{ end }}
+        {{ with .description }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
       </div>
     </div>
     <div class="row">
@@ -116,7 +116,7 @@
             {{ range .testimonial_slider }}
             <div>
               <i class="ion-quote"></i>
-              {{ with .content }}<p>{{ . | markdownify }}</p>{{ end }}
+              {{ with .content }}{{ . | $.Page.RenderString (dict "display" "block") }}{{ end }}
               <div class="user">
                 <img src="{{ .image | relURL }}" alt="client">
                 <p><span>{{ .name | markdownify }}</span> {{ .designation | markdownify }}</p>

--- a/layouts/partials/date_i18n.html
+++ b/layouts/partials/date_i18n.html
@@ -1,3 +1,9 @@
-{{/* Localize .PublishDate; returns the standard English "January 2, 2006" format, if no language-specific override exists */ -}}
-{{ $lang := $.Page.Language.Lang }}{{ $date := .PublishDate }}{{ if eq $lang "de" }}{{ $date.Day }}. {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else if in (slice "fr" "it") $lang }}{{ $date.Day }} {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else }}{{ $date.Format "January 2, 2006" }}{{ end }}
-{{- /* Dummy comment to strip trailing newline */ -}}
+{{/* Localize a date; expects a `dict` with keys `date` and `lang`; returns the standard English "January 2, 2006" format, if no language-specific override exists */ -}}
+{{ if eq .lang "de" -}}
+  {{ .date.Day }}. {{ i18n (lower .date.Month) }} {{ .date.Year -}}
+{{ else if in (slice "fr" "it") .lang -}}
+  {{ .date.Day }} {{ i18n (lower .date.Month) }} {{ .date.Year -}}
+{{ else -}}
+  {{ .date.Format "January 2, 2006" -}}
+{{ end -}}
+{{/* Dummy comment to strip trailing newline */ -}}

--- a/layouts/partials/widgets/recent_posts.html
+++ b/layouts/partials/widgets/recent_posts.html
@@ -3,7 +3,9 @@
     {{ range first 4 (where site.Pages "Type" "post") }}
     <div class="media">
       <a class="pull-left" href="{{ .RelPermalink }}">
-        <img class="media-object" src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
+        {{ if isset .Params "image" }}
+        <img class="media-object" src="{{ .Params.image | relURL }}" alt="{{ .Title }}">
+        {{ end }}
       </a>
       <div class="media-body">
         <h4 class="media-heading"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h4>

--- a/layouts/project/list.html
+++ b/layouts/project/list.html
@@ -29,10 +29,14 @@
           <div class="row shuffle-wrapper">
             {{ range .Data.Pages }}
             <div class="col-md-4 portfolio-item shuffle-item" data-groups="[&quot;{{ .Params.Category | urlize }}&quot;]">
-              <img src="{{ .Params.Image | relURL }}" alt="{{ .Title }}">
+              {{ if isset .Params "image" }}
+              <img src="{{ .Params.image | relURL }}" alt="{{ .Title }}">
+              {{ end }}
               <div class="portfolio-hover">
                 <div class="portfolio-content">
-                  <a href="{{ .Params.Image | relURL }}" class="portfolio-popup"><i class="icon ion-search"></i></a>
+                  {{ with .Params.image }}
+                  <a href="{{ . | relURL }}" class="portfolio-popup"><i class="icon ion-search"></i></a>
+                  {{ end }}
                   <a class="h3" href="{{ .RelPermalink }}">{{ .Title }}</a>
                   <p>{{ .Params.Description }}</p>
                 </div>

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -8,7 +8,9 @@
   <div class="container">
     <div class="row">
       <div class="col-md-8">
-        <img class="img-responsive w-100" src="{{ .Params.Image | relURL }}" alt="">
+        {{ with .Params.image }}
+        <img class="img-responsive w-100" src="{{ . | relURL }}" alt="">
+        {{ end }}
       </div>
       <div class="col-md-4">
         <div class="project-details">

--- a/layouts/shortcodes/date_i18n.html
+++ b/layouts/shortcodes/date_i18n.html
@@ -1,7 +1,15 @@
 <!-- {{/*
-Localize a date string like "2006-01-02"; returns the standard English "January 2, 2006" format, if no language-specific override is defined in the shortcode's source
+Localize a date string like "2006-01-02"; returns the standard English "January 2, 2006" format, if no language-specific override exists
 
 Usage: {{< date_i18n DATE >}}
 */}} -->
-{{- $lang := $.Site.Language.Lang }}{{ $date := time (.Get 0) }}{{ if eq $lang "de" }}{{ $date.Day }}. {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else if in (slice "fr" "it") $lang }}{{ $date.Day }} {{ i18n (lower $date.Month) }} {{ $date.Year }}{{ else }}{{ $date.Format "January 2, 2006" }}{{ end -}}
-{{- /* Dummy comment to strip trailing newline */ -}}
+{{- $lang := $.Site.Language.Lang -}}
+{{ $date := time (.Get 0) -}}
+{{ if eq $lang "de" -}}
+  {{ $date.Day }}. {{ i18n (lower $date.Month) }} {{ $date.Year -}}
+{{ else if in (slice "fr" "it") $lang -}}
+  {{ $date.Day }} {{ i18n (lower $date.Month) }} {{ $date.Year -}}
+{{ else -}}
+  {{ $date.Format "January 2, 2006" -}}
+{{ end -}}
+{{/* Dummy comment to strip trailing newline */ -}}


### PR DESCRIPTION
- Use [`.Page.RenderString (dict "display" 
"block")`](https://gohugo.io/functions/renderstring/) instead of 
`markdownify` for user-defined texts that possibly include multiple 
paragraphs. See https://github.com/gohugoio/hugo/issues/5975 for the 
underlying issue.

- Make the `date_i18n.html` partial work with any date (not tied to 
`PublishDate` anymore) and pretty-format `date_i18n.html` shortcode.

- Localize last modification date on FAQ page.

- Improve templates to be more robust/flexible, i.a. when individual 
fields in corresponding `content/` files are missing or blank.