### PR TITLE
Fix i18n warnings (again) in Hugo v0.83.1:

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,75 +1,40 @@
-# Regular translations
-[404_message]
-other = "Tut uns leid – diese Seite scheint nicht (mehr) hier zu sein."
-[address_title]
-other = "Adresse"
-[all]
-other = "Alle"
-[buy_now]
-other = "Kaufen"
-[categories]
-other = "Kategorien"
-[contact_form_email]
-other = "Ihre E-Mail-Adresse"
-[contact_form_message]
-other = "Nachricht"
-[contact_form_name]
-other = "Ihr Name"
-[contact_form_subject]
-other = "Betreff"
-[email]
-other = "E-Mail"
-[faq_toc_title]
-other = "Inhalt"
-[form_respond]
-other = "Vielen Dank für Ihre Nachricht. Wir werden uns so bald als möglich bei Ihnen melden."
-[form_submitted]
-other = "Ihre Nachricht wurde erfolgreich übermittelt"
-[go_home]
-other = "Zur Startseite"
-[last_update]
-other = "Letzte Aktualisierung"
-[latest_posts]
-other = "Letzte Einträge"
-[location]
-other = "Ort"
-[page_next]
-other = "Ältere"
-[page_prev]
-other = "Neuere"
-[phone]
-other = "Telefon"
-[posted_by]
-other = "Von"
-[read_more]
-other = "Weiterlesen"
-[submit]
-other = "Nachricht senden"
-[tags]
-other = "Schlagwörter"
+# Simple translations without pluralization rules
+## Regular
+404_message = "Tut uns leid – diese Seite scheint nicht (mehr) hier zu sein."
+address_title = "Adresse"
+all = "Alle"
+buy_now = "Kaufen"
+categories = "Kategorien"
+contact_form_email = "Ihre E-Mail-Adresse"
+contact_form_message = "Nachricht"
+contact_form_name = "Ihr Name"
+contact_form_subject = "Betreff"
+email = "E-Mail"
+faq_toc_title = "Inhalt"
+form_respond = "Vielen Dank für Ihre Nachricht. Wir werden uns so bald als möglich bei Ihnen melden."
+form_submitted = "Ihre Nachricht wurde erfolgreich übermittelt"
+go_home = "Zur Startseite"
+last_update = "Letzte Aktualisierung"
+latest_posts = "Letzte Einträge"
+location = "Ort"
+page_next = "Ältere"
+page_prev = "Neuere"
+phone = "Telefon"
+posted_by = "Von"
+read_more = "Weiterlesen"
+submit = "Nachricht senden"
+tags = "Schlagwörter"
 
-# Dates
-[january]
-other = "Januar"
-[february]
-other = "Februar"
-[march]
-other = "März"
-[april]
-other = "April"
-[may]
-other = "Mai"
-[june]
-other = "Juni"
-[july]
-other = "Juli"
-[august]
-other = "August"
-[september]
-other = "September"
-[october]
-other = "Oktober"
-[november]
-other = "November"
-[december]
-other = "Dezember"
+## Dates
+january = "Januar"
+february = "Februar"
+march = "März"
+april = "April"
+may = "Mai"
+june = "Juni"
+july = "Juli"
+august = "August"
+september = "September"
+october = "Oktober"
+november = "November"
+december = "Dezember"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,75 +1,40 @@
-# Regular translations
-[404_message]
-other = "Sorry – this page does not seem to exist (anymore)."
-[address_title]
-other = "Address"
-[all]
-other = "All"
-[buy_now]
-other = "Buy now"
-[categories]
-other = "Categories"
-[contact_form_email]
-other = "Your e-mail address"
-[contact_form_message]
-other = "Message"
-[contact_form_name]
-other = "Your name"
-[contact_form_subject]
-other = "Subject"
-[email]
-other = "E-mail"
-[faq_toc_title]
-other = "Outline"
-[form_respond]
-other = "Thank you for your message. We will get back to you as soon as possible."
-[form_submitted]
-other = "Your message was successfully submitted"
-[go_home]
-other = "To the home page"
-[last_update]
-other = "Last updated"
-[latest_posts]
-other = "Latest Posts"
-[location]
-other = "Location"
-[page_next]
-other = "Older"
-[page_prev]
-other = "Newer"
-[phone]
-other = "Phone"
-[posted_by]
-other = "Posted by"
-[read_more]
-other = "Continue reading"
-[submit]
-other = "Send message"
-[tags]
-other = "Tags"
+# Simple translations without pluralization rules
+## Regular
+404_message = "Sorry – this page does not seem to exist (anymore)."
+address_title = "Address"
+all = "All"
+buy_now = "Buy now"
+categories = "Categories"
+contact_form_email = "Your e-mail address"
+contact_form_message = "Message"
+contact_form_name = "Your name"
+contact_form_subject = "Subject"
+email = "E-mail"
+faq_toc_title = "Outline"
+form_respond = "Thank you for your message. We will get back to you as soon as possible."
+form_submitted = "Your message was successfully submitted"
+go_home = "To the home page"
+last_update = "Last updated"
+latest_posts = "Latest Posts"
+location = "Location"
+page_next = "Older"
+page_prev = "Newer"
+phone = "Phone"
+posted_by = "Posted by"
+read_more = "Continue reading"
+submit = "Send message"
+tags = "Tags"
 
-# Dates
-[january]
-other = "January"
-[february]
-other = "February"
-[march]
-other = "March"
-[april]
-other = "April"
-[may]
-other = "May"
-[june]
-other = "June"
-[july]
-other = "July"
-[august]
-other = "August"
-[september]
-other = "September"
-[october]
-other = "October"
-[november]
-other = "November"
-[december]
-other = "December"
+## Dates
+january = "January"
+february = "February"
+march = "March"
+april = "April"
+may = "May"
+june = "June"
+july = "July"
+august = "August"
+september = "September"
+october = "October"
+november = "November"
+december = "December"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,75 +1,40 @@
-# Regular translations
-[404_message]
-one = "Désolé – cette page ne semble pas exister (plus)."
-[address_title]
-one = "Adresse"
-[all]
-one = "Tous"
-[buy_now]
-one = "Acheter"
-[categories]
-one = "Catégories"
-[contact_form_email]
-one = "Votre adresse e-mail"
-[contact_form_message]
-one = "Message"
-[contact_form_name]
-one = "Votre nom"
-[contact_form_subject]
-one = "Objet"
-[email]
-one = "E-mail"
-[faq_toc_title]
-one = "Sommaire"
-[form_respond]
-one = "Merci pour votre message. Nous vous répondrons dans les plus brefs délais."
-[form_submitted]
-one = "Votre message a été transmis avec succès"
-[go_home]
-one = "À la paaaage d'accueil"
-[last_update]
-one = "Dernière mise à jour"
-[latest_posts]
-one = "Derniers articles"
-[location]
-one = "Lieu"
-[page_next]
-one = "Plus anciens"
-[page_prev]
-one = "Plus récents"
-[phone]
-one = "Téléphone"
-[posted_by]
-one = "Par"
-[read_more]
-one = "Lire la suite"
-[submit]
-one = "Envoyer le message"
-[tags]
-one = "Mots clefs"
+# Simple translations without pluralization rules
+## Regular
+404_message = "Désolé – cette page ne semble pas exister (plus)."
+address_title = "Adresse"
+all = "Tous"
+buy_now = "Acheter"
+categories = "Catégories"
+contact_form_email = "Votre adresse e-mail"
+contact_form_message = "Message"
+contact_form_name = "Votre nom"
+contact_form_subject = "Objet"
+email = "E-mail"
+faq_toc_title = "Sommaire"
+form_respond = "Merci pour votre message. Nous vous répondrons dans les plus brefs délais."
+form_submitted = "Votre message a été transmis avec succès"
+go_home = "À la page d'accueil"
+last_update = "Dernière mise à jour"
+latest_posts = "Derniers articles"
+location = "Lieu"
+page_next = "Plus anciens"
+page_prev = "Plus récents"
+phone = "Téléphone"
+posted_by = "Par"
+read_more = "Lire la suite"
+submit = "Envoyer le message"
+tags = "Mots clefs"
 
-# Dates
-[january]
-one = "janvier"
-[february]
-one = "février"
-[march]
-one = "mars"
-[april]
-one = "avril"
-[may]
-one = "mai"
-[june]
-one = "juin"
-[july]
-one = "juillet"
-[august]
-one = "août"
-[september]
-one = "septembre"
-[october]
-one = "octobre"
-[november]
-one = "novembre"
-[december]
-one = "décembre"
+## Dates
+january = "janvier"
+february = "février"
+march = "mars"
+april = "avril"
+may = "mai"
+june = "juin"
+july = "juillet"
+august = "août"
+september = "septembre"
+october = "octobre"
+november = "novembre"
+december = "décembre"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -1,75 +1,40 @@
-# Regular translations
-[404_message]
-other = "Spiacente – questa pagina non sembra esistere (più)."
-[address_title]
-other = "Indirizzo"
-[all]
-other = "Tutti"
-[buy_now]
-other = "Comprare"
-[categories]
-other = "Categories"
-[contact_form_email]
-other = "Il suo indirizzo e-mail"
-[contact_form_message]
-other = "Messaggio"
-[contact_form_name]
-other = "Il suo nome"
-[contact_form_subject]
-other = "Oggetto"
-[email]
-other = "E-mail"
-[faq_toc_title]
-other = "Sommario"
-[form_respond]
-other = "Grazie per il suo messaggio. Vi risponderemo il più presto possibile."
-[form_submitted]
-other = "Il suo messaggio è stato trasmesso con successo"
-[go_home]
-other = "Alla pagina iniziale"
-[last_update]
-other = "Ultimo aggiornamento"
-[latest_posts]
-other = "Ultimi articoli"
-[location]
-other = "Luogo"
-[page_next]
-other = "Più vecchi"
-[page_prev]
-other = "Più recenti"
-[phone]
-other = "Telefono"
-[posted_by]
-other = "Da"
-[read_more]
-other = "Leggi di più"
-[submit]
-other = "Invia messaggio"
-[tags]
-other = "Parole chiave"
+# Simple translations without pluralization rules
+## Regular
+404_message = "Spiacente – questa pagina non sembra esistere (più)."
+address_title = "Indirizzo"
+all = "Tutti"
+buy_now = "Comprare"
+categories = "Categories"
+contact_form_email = "Il suo indirizzo e-mail"
+contact_form_message = "Messaggio"
+contact_form_name = "Il suo nome"
+contact_form_subject = "Oggetto"
+email = "E-mail"
+faq_toc_title = "Sommario"
+form_respond = "Grazie per il suo messaggio. Vi risponderemo il più presto possibile."
+form_submitted = "Il suo messaggio è stato trasmesso con successo"
+go_home = "Alla pagina iniziale"
+last_update = "Ultimo aggiornamento"
+latest_posts = "Ultimi articoli"
+location = "Luogo"
+page_next = "Più vecchi"
+page_prev = "Più recenti"
+phone = "Telefono"
+posted_by = "Da"
+read_more = "Leggi di più"
+submit = "Invia messaggio"
+tags = "Parole chiave"
 
-# Dates
-[january]
-other = "gennaio"
-[february]
-other = "febbraio"
-[march]
-other = "marzo"
-[april]
-other = "aprile"
-[may]
-other = "maggio"
-[june]
-other = "giugno"
-[july]
-other = "luglio"
-[august]
-other = "agosto"
-[september]
-other = "settembre"
-[october]
-other = "ottobre"
-[november]
-other = "novembre"
-[december]
-other = "dicembre"
+## Dates
+january = "gennaio"
+february = "febbraio"
+march = "marzo"
+april = "aprile"
+may = "maggio"
+june = "giugno"
+july = "luglio"
+august = "agosto"
+september = "settembre"
+october = "ottobre"
+november = "novembre"
+december = "dicembre"


### PR DESCRIPTION
Hugo [v0.83.1](https://github.com/gohugoio/hugo/releases/tag/v0.83.1) reverted things changed in v0.83, so #147 is a non-solution now.

I've changed i18n files to use the [simple/old translation formalism](https://github.com/gohugoio/hugo/pull/8497#issuecomment-830820941) which [hopefully stays the recommended way to define translations without pluralization rules in Hugo](https://github.com/gohugoio/hugo/pull/8497#issuecomment-831169636)