### PR TITLE
Avoid usage of `.Scratch`

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,15 +9,15 @@
   <div class="container">
     <div class="row">
       <div class="col-md-8">
-        {{ $paginator := .Paginate .Data.Pages }}
-        {{ range $paginator.Pages }}
+        {{ $paginator := .Paginate .Data.Pages -}}
+        {{ range $paginator.Pages -}}
         <div class="post">
           <div class="post-media post-thumb">
-            {{ if isset .Params "image" }}
+            {{ if isset .Params "image" -}}
             <a href="{{ .RelPermalink }}">
               <img src="{{ .Params.image | relURL }}" alt="{{ .Title }}">
             </a>
-            {{ end }}
+            {{- end }}
           </div>
           <h3 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
           <div class="post-meta">
@@ -25,8 +25,8 @@
               <li><i class="ion-calendar"></i> {{ partial "date_i18n.html" (dict "date" .PublishDate "lang" .Page.Language.Lang) }}</li>
               <li><i class="ion-android-people"></i>
                 {{ i18n "posted_by" }}
-                {{ $scratch := newScratch }}{{ if reflect.IsSlice .Params.author }}{{ $scratch.Set "authors" .Params.author }}{{ else }}{{ $scratch.Set "authors" (slice .Params.author) }}{{ end }}
-                {{ range $index, $elements := $scratch.Get "authors" }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
+                {{ $authors := slice }}{{ if reflect.IsSlice .Params.author }}{{ $authors = .Params.author }}{{ else }}{{ $authors = (slice .Params.author) }}{{ end -}}
+                {{ range $index, $elements := $authors }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
               </li>
               <li><i class="ion-pricetags"></i>
                 {{ range $index, $elements:= .Params.Tags }}{{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . }}</a>{{ end }}
@@ -38,70 +38,70 @@
             <a href="{{ .RelPermalink }}" class="btn btn-main">{{ i18n "read_more" }}</a>
           </div>
         </div>
-        {{ end }}
+        {{- end }}
 
 				<!-- pagination -->
-				{{ $paginator := .Paginator }}
-				{{ $adjacent_links := 2 }}
-				{{ $max_links := (add (mul $adjacent_links 2) 1) }}
-				{{ $lower_limit := (add $adjacent_links 1) }}
-				{{ $upper_limit := (sub $paginator.TotalPages $adjacent_links) }}
-				{{ if gt $paginator.TotalPages 1 }}
+				{{ $paginator := .Paginator -}}
+				{{ $adjacent_links := 2 -}}
+				{{ $max_links := (add (mul $adjacent_links 2) 1) -}}
+				{{ $lower_limit := (add $adjacent_links 1) -}}
+				{{ $upper_limit := (sub $paginator.TotalPages $adjacent_links) -}}
+				{{ if gt $paginator.TotalPages 1 -}}
 				<nav class="text-center">
 					<ul class="pagination post-pagination">
 						<!-- Previous page. -->
-						{{ if $paginator.HasPrev }}
+						{{ if $paginator.HasPrev -}}
 						<li>
 							<a href="{{ $paginator.Prev.URL }}" class="page-link">{{ i18n "page_prev" }}</a>
             </li>
-            {{ end }}
+            {{- end }}
 						<!-- Page numbers. -->
-						{{ range $paginator.Pagers }}
-						{{ $.Scratch.Set "page_number_flag" false }}
+						{{ range $paginator.Pagers -}}
+						{{ $page_number_flag := false -}}
 						<!-- Advanced page numbers. -->
-						{{ if gt $paginator.TotalPages $max_links }}
+						{{ if gt $paginator.TotalPages $max_links -}}
 						<!-- Lower limit pages. -->
 						<!-- If the user is on a page which is in the lower limit.  -->
-						{{ if le $paginator.PageNumber $lower_limit }}
+						{{ if le $paginator.PageNumber $lower_limit -}}
 						<!-- If the current loop page is less than max_links. -->
-						{{ if le .PageNumber $max_links }}
-						{{ $.Scratch.Set "page_number_flag" true }}
-						{{ end }}
+						{{ if le .PageNumber $max_links -}}
+						{{ $page_number_flag = true -}}
+						{{ end -}}
 						<!-- Upper limit pages. -->
 						<!-- If the user is on a page which is in the upper limit. -->
-						{{ else if ge $paginator.PageNumber $upper_limit }}
+						{{ else if ge $paginator.PageNumber $upper_limit -}}
 						<!-- If the current loop page is greater than total pages minus $max_links -->
-						{{ if gt .PageNumber (sub $paginator.TotalPages $max_links) }}
-						{{ $.Scratch.Set "page_number_flag" true }}
-						{{ end }}
+						{{ if gt .PageNumber (sub $paginator.TotalPages $max_links) -}}
+						{{ $page_number_flag = true -}}
+						{{ end -}}
 						<!-- Middle pages. -->
-						{{ else }}
-						{{ if and ( ge .PageNumber (sub $paginator.PageNumber $adjacent_links) ) ( le .PageNumber (add $paginator.PageNumber $adjacent_links) ) }}
-						{{ $.Scratch.Set "page_number_flag" true }}
-						{{ end }}
-						{{ end }}
+						{{ else -}}
+						{{ if and (ge .PageNumber (sub $paginator.PageNumber $adjacent_links)) (le .PageNumber (add $paginator.PageNumber $adjacent_links)) -}}
+						{{ $page_number_flag = true -}}
+						{{ end -}}
+						{{ end -}}
 						<!-- Simple page numbers. -->
-						{{ else }}
-						{{ $.Scratch.Set "page_number_flag" true }}
-						{{ end }}
+						{{ else -}}
+						{{ $page_number_flag = true -}}
+						{{ end -}}
 						<!-- Output page numbers. -->
-						{{ if eq ($.Scratch.Get "page_number_flag") true }}
+						{{ if eq $page_number_flag true -}}
 						<li class="{{ if eq . $paginator }} active {{ end }}">
 							<a href="{{ .URL }}">
 								{{ .PageNumber }}
 							</a>
 						</li>
-						{{ end }}
-						{{ end }}
+						{{- end }}
+						{{- end }}
 						<!-- Next page. -->
-						{{ if $paginator.HasNext }}
+						{{ if $paginator.HasNext -}}
 						<li>
 							<a href="{{ $paginator.Next.URL }}">{{ i18n "page_next" }}</a>
 						</li>
-						{{ end }}
+						{{- end }}
 					</ul>
 				</nav>
-				{{ end }}
+				{{- end }}
       </div>
       <div class="col-md-4">
         {{ partial "blog-sidebar.html" . }}
@@ -111,9 +111,9 @@
 </div>
 
 <!-- regular page -->
-{{ else }}
+{{ else -}}
 {{ .Render "default" }}
-{{ end }}
+{{- end }}
 <!-- /regular page -->
 
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,8 +16,8 @@
               <li><i class="ion-calendar"></i> {{ partial "date_i18n.html" (dict "date" .PublishDate "lang" .Page.Language.Lang) }}</li>
               <li><i class="ion-android-people"></i>
                 {{ i18n "posted_by" }}
-                {{ $scratch := newScratch }}{{ if reflect.IsSlice .Params.author }}{{ $scratch.Set "authors" .Params.author }}{{ else }}{{ $scratch.Set "authors" (slice .Params.author) }}{{ end }}
-                {{ range $index, $elements := $scratch.Get "authors" }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
+                {{ $authors := slice }}{{ if reflect.IsSlice .Params.author }}{{ $authors = .Params.author }}{{ else }}{{ $authors = (slice .Params.author) }}{{ end -}}
+                {{ range $index, $elements := $authors }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
               </li>
               <li><i class="ion-pricetags"></i>
                 {{ range $index, $elements:= .Params.Tags }}{{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . }}</a>{{ end }}
@@ -25,9 +25,9 @@
             </ul>
 					</div>
 					<div class="post-thumb">
-            {{ with .Params.image }}
+            {{ with .Params.image -}}
 						<img class="img-responsive" src="{{ . | relURL }}" alt="{{ $.Title }}">
-            {{ end }}
+            {{- end }}
 					</div>
 					<div class="post-content post-excerpt">
 						{{ .Content }}
@@ -45,9 +45,9 @@
 </section>
 
 <!-- regular page -->
-{{ else }}
+{{ else -}}
 {{ .Render "default" }}
-{{ end }}
+{{- end }}
 <!-- /regular page -->
 
 {{ end }}

--- a/layouts/author/single.html
+++ b/layouts/author/single.html
@@ -8,12 +8,12 @@
 			<div class="col-md-8 col-md-offset-2">
 				<div class="text-center">
 					<figure>
-						{{ if .Params.Photo }}
+						{{ if .Params.Photo -}}
 						<img style="border-radius: 50%;" class="img-fluid" src="{{.Params.Photo}}">
-						{{else if .Params.Email}}
+						{{ else if .Params.Email -}}
 						<img style="border-radius: 50%;" class="img-fluid"
 							src="https://www.gravatar.com/avatar/{{ md5 .Params.email }}?s=128&pg&d=identicon">
-						{{ end }}
+						{{- end }}
 						<figcaption>
 							<h5 class="font-weight-bold">
 								{{ .Params.Name }}
@@ -24,10 +24,9 @@
 					{{ .Content }}
 					<hr>
 					<ul class="list-inline">
-						{{ range .Params.Social }}
-						<li class="list-inline-item"><a class="share-icon bg-secondary" href="{{ .link | safeURL}}"><i
-									class="{{ .icon }}"></i></a></li>
-						{{ end }}
+						{{ range .Params.Social -}}
+						<li class="list-inline-item"><a class="share-icon bg-secondary" href="{{ .link | safeURL}}"><i class="{{ .icon }}"></i></a></li>
+						{{- end }}
 					</ul>
 				</div>
 			</div>
@@ -43,15 +42,15 @@
 					<h2>{{ i18n "posted_by" }} {{ .Title }}</h2>
 				</div>
 			</div>
-			{{ range (union (where site.RegularPages "Params.author" "intersect" (slice .Title)) (where site.RegularPages "Params.author" .Title)) }}
+			{{ range (union (where site.RegularPages "Params.author" "intersect" (slice .Title)) (where site.RegularPages "Params.author" .Title)) -}}
 			<div class="col-md-6">
 				<div class="post">
 					<div class="post-thumb">
-            {{ if isset .Params "image" }}
+            {{ if isset .Params "image" -}}
 						<a href="{{ .RelPermalink }}">
 							<img class="img-responsive" src="{{ .Params.image | relURL }}" alt="{{ .Title }}">
 						</a>
-            {{ end }}
+            {{- end }}
 					</div>
 					<h3 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
 					<div class="post-meta">
@@ -59,8 +58,8 @@
 							<li><i class="ion-calendar"></i> {{ partial "date_i18n.html" (dict "date" .PublishDate "lang" .Page.Language.Lang) }}</li>
               <li><i class="ion-android-people"></i>
                 {{ i18n "posted_by" }}
-                {{ $scratch := newScratch }}{{ if reflect.IsSlice .Params.author }}{{ $scratch.Set "authors" .Params.author }}{{ else }}{{ $scratch.Set "authors" (slice .Params.author) }}{{ end }}
-                {{ range $index, $elements := $scratch.Get "authors" }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
+                {{ $authors := slice }}{{ if reflect.IsSlice .Params.author }}{{ $authors = .Params.author }}{{ else }}{{ $authors = (slice .Params.author) }}{{ end -}}
+                {{ range $index, $elements := $authors }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
               </li>
               <li><i class="ion-pricetags"></i>
                 {{ range $index, $elements:= .Params.Tags }}{{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . }}</a>{{ end }}
@@ -73,7 +72,7 @@
 					</div>
 				</div>
 			</div>
-			{{ end }}
+			{{- end }}
 		</div>
 	</div>
 </section>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,9 +1,9 @@
-<!-- Header Start -->
+<!-- Header -->
 <header class="navigation">
   <div class="container-fluid">
     <div class="row">
       <div class="col-md-12">
-        <!-- header Nav Start -->
+        <!-- Header Nav -->
         <nav class="navbar">
           <!-- Brand and toggle get grouped for better mobile display -->
           <div class="navbar-header">
@@ -23,12 +23,13 @@
               {{ range site.Menus.main -}}
               {{ if .HasChildren -}}
               <li class="dropdown">
-                <a href="#" class="dropdown-toggle{{ if $currentPage.HasMenuCurrent "main" . }} current-parent{{ end }}" data-toggle="dropdown" role="button" aria-haspopup="true"
-                  aria-expanded="false">{{ .Name }} <span class="ion-ios-arrow-down"></span></a>
+                <a href="#" class="dropdown-toggle{{ if $currentPage.HasMenuCurrent "main" . }} current-parent{{ end }}" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                  {{ .Name }} <span class="ion-ios-arrow-down"></span>
+                </a>
                 <ul class="dropdown-menu">
                   {{ range .Children -}}
                   <li><a href="{{ .URL | relLangURL }}"{{ if $currentPage.IsMenuCurrent "main" . }} class="current"{{ end }}>{{ .Name }}</a></li>
-                  {{ end -}}
+                  {{- end }}
                 </ul>
               </li>
               {{ else -}}
@@ -42,8 +43,8 @@
                 <select id="select-language" onchange="location = this.value;">
                   {{ $siteLanguages := site.Languages -}}
                   {{ $pageLang := .Page.Lang -}}
-                  {{ $scratch := newScratch }}{{ if eq .Page.Kind "404" }}{{ $scratch.Set "translations" site.Home.AllTranslations }}{{ else }}{{ $scratch.Set "translations" .Page.AllTranslations }}{{ end -}}
-                  {{ range ($scratch.Get "translations") -}}
+                  {{ $translations := "" }}{{ if eq .Page.Kind "404" }}{{ $translations = site.Home.AllTranslations }}{{ else }}{{ $translations = .Page.AllTranslations }}{{ end -}}
+                  {{ range $translations -}}
                   {{ $translation := . -}}
                   {{ range $siteLanguages -}}
                   {{ if eq $translation.Lang .Lang -}}
@@ -63,10 +64,13 @@
                 </select>
               </li>
               {{- end }}
+              <!-- /Language List -->
             </ul>
-          </div><!-- /.navbar-collapse -->
+          </div>
         </nav>
+        <!-- /Header Nav -->
       </div>
     </div>
   </div>
-</header><!-- header close -->
+</header>
+<!-- /Header -->


### PR DESCRIPTION
As I've learned yesterday, [`.Scratch`](https://gohugo.io/functions/scratch) isn't necessary anymore in most cases since the original scoping issue of template vars has been fixed in Go 1.11 (or Hugo 0.48 respectively). For more info, see [this blog post](https://regisphilibert.com/blog/2017/04/hugo-scratch-explained-variable/).

Avoiding `.Scratch` leads to simpler code that's easier to understand, especially for newcomers.

Additionally, this PR brings some cosmetic changes.