### PR TITLE
Harmonize go template syntax

### DIFF
--- a/layouts/_default/about.html
+++ b/layouts/_default/about.html
@@ -97,13 +97,13 @@
         <div class="tabCommon">
           <ul class="nav nav-tabs">
             {{ range $index, $elements := .tabs }}
-            <li {{ if eq $index 0}} class="active" {{ end }}><a href="#{{.name | urlize}}"
-                data-toggle="tab">{{.name}}</a></li>
+            <li {{ if eq $index 0 }} class="active" {{ end }}><a href="#{{ .name | urlize }}"
+                data-toggle="tab">{{ .name }}</a></li>
             {{ end }}
           </ul>
           <div class="tab-content">
             {{ range $index, $elements := .tabs }}
-            <div id="{{.name | urlize}}" class="tab-pane fade {{ if eq $index 0}} active in {{ end }}">
+            <div id="{{ .name | urlize }}" class="tab-pane fade {{ if eq $index 0 }} active in {{ end }}">
               {{ .content | $.Page.RenderString (dict "display" "block") }}
             </div>
             {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -29,7 +29,7 @@
                 {{ range $index, $elements := $authors }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
               </li>
               <li><i class="ion-pricetags"></i>
-                {{ range $index, $elements:= .Params.Tags }}{{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . }}</a>{{ end }}
+                {{ range $index, $elements:= .Params.tags }}{{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . }}</a>{{ end }}
               </li>
             </ul>
           </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -20,7 +20,7 @@
                 {{ range $index, $elements := $authors }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
               </li>
               <li><i class="ion-pricetags"></i>
-                {{ range $index, $elements:= .Params.Tags }}{{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . }}</a>{{ end }}
+                {{ range $index, $elements:= .Params.tags }}{{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . }}</a>{{ end }}
               </li>
             </ul>
           </div>

--- a/layouts/author/single.html
+++ b/layouts/author/single.html
@@ -9,7 +9,7 @@
         <div class="text-center">
           <figure>
             {{ if .Params.Photo -}}
-            <img style="border-radius: 50%;" class="img-fluid" src="{{.Params.Photo}}">
+            <img style="border-radius: 50%;" class="img-fluid" src="{{ .Params.Photo }}">
             {{ else if .Params.Email -}}
             <img style="border-radius: 50%;" class="img-fluid"
               src="https://www.gravatar.com/avatar/{{ md5 .Params.email }}?s=128&pg&d=identicon">
@@ -25,7 +25,7 @@
           <hr>
           <ul class="list-inline">
             {{ range .Params.Social -}}
-            <li class="list-inline-item"><a class="share-icon bg-secondary" href="{{ .link | safeURL}}"><i class="{{ .icon }}"></i></a></li>
+            <li class="list-inline-item"><a class="share-icon bg-secondary" href="{{ .link | safeURL }}"><i class="{{ .icon }}"></i></a></li>
             {{- end }}
           </ul>
         </div>

--- a/layouts/author/single.html
+++ b/layouts/author/single.html
@@ -8,15 +8,15 @@
       <div class="col-md-8 col-md-offset-2">
         <div class="text-center">
           <figure>
-            {{ if .Params.Photo -}}
-            <img style="border-radius: 50%;" class="img-fluid" src="{{ .Params.Photo }}">
-            {{ else if .Params.Email -}}
+            {{ if .Params.photo -}}
+            <img style="border-radius: 50%;" class="img-fluid" src="{{ .Params.photo }}">
+            {{ else if .Params.email -}}
             <img style="border-radius: 50%;" class="img-fluid"
               src="https://www.gravatar.com/avatar/{{ md5 .Params.email }}?s=128&pg&d=identicon">
             {{- end }}
             <figcaption>
               <h5 class="font-weight-bold">
-                {{ .Params.Name }}
+                {{ .Params.name }}
               </h5>
             </figcaption>
           </figure>
@@ -24,7 +24,7 @@
           {{ .Content }}
           <hr>
           <ul class="list-inline">
-            {{ range .Params.Social -}}
+            {{ range .Params.social -}}
             <li class="list-inline-item"><a class="share-icon bg-secondary" href="{{ .link | safeURL }}"><i class="{{ .icon }}"></i></a></li>
             {{- end }}
           </ul>
@@ -62,7 +62,7 @@
                 {{ range $index, $elements := $authors }}{{ if ne $index 0 }}, {{ end }}<a class="text-primary" href="{{ `author/` | relLangURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
               </li>
               <li><i class="ion-pricetags"></i>
-                {{ range $index, $elements:= .Params.Tags }}{{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . }}</a>{{ end }}
+                {{ range $index, $elements:= .Params.tags }}{{ if ne $index 0 }}, {{ end }}<a href="{{ `tags/` | relLangURL }}{{ . | lower }}">{{ . }}</a>{{ end }}
               </li>
             </ul>
           </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 <!-- banner -->
 {{ with .Params.banner }}
 {{ if .enable }}
-<section class="slider {{if .bg_overlay}}overly{{end}}" style="background-image: url('{{ .bg_image | relURL }}');">
+<section class="slider {{ if .bg_overlay }}overly{{ end }}" style="background-image: url('{{ .bg_image | relURL }}');">
   <div class="container">
     <div class="row">
       <div class="col-md-12">
@@ -54,7 +54,7 @@
 <!-- portfolio -->
 {{ with .Params.portfolio }}
 {{ if .enable }}
-<section class="feature bg-2" style="background-image: url('{{ .bg_image | relURL}}')">
+<section class="feature bg-2" style="background-image: url('{{ .bg_image | relURL }}')">
   <div class="container">
     <div class="row">
       <div class="col-md-6 col-md-offset-6">
@@ -129,8 +129,8 @@
     </div>
   </div>
 </section>
-{{ end}}
-{{ end}}
+{{ end }}
+{{ end }}
 <!-- /funfacts -->
 
 {{ end }}

--- a/layouts/partials/cta.html
+++ b/layouts/partials/cta.html
@@ -1,6 +1,6 @@
 {{ with site.GetPage "/" }}
 {{ with .Params.cta }}
-<section class="call-to-action bg-1 section-sm overly" style="background-image: url('{{.bg_image | relURL }}');">
+<section class="call-to-action bg-1 section-sm overly" style="background-image: url('{{ .bg_image | relURL }}');">
   <div class="container">
     <div class="row">
       <div class="col-md-12">

--- a/layouts/partials/page-title.html
+++ b/layouts/partials/page-title.html
@@ -1,10 +1,10 @@
-<section class="page-title bg-2" style="background-image: url('{{ .Params.Bg_image | relURL }}');">
+<section class="page-title bg-2" style="background-image: url('{{ .Params.bg_image | relURL }}');">
   <div class="container">
     <div class="row">
       <div class="col-md-12">
         <div class="block">
           <h1>{{ .Title }}</h1>
-          <p>{{ .Params.Description }}</p>
+          <p>{{ .Params.description }}</p>
         </div>
       </div>
     </div>

--- a/layouts/partials/page-title.html
+++ b/layouts/partials/page-title.html
@@ -1,4 +1,4 @@
-<section class="page-title bg-2" style="background-image: url('{{.Params.Bg_image | relURL}}');">
+<section class="page-title bg-2" style="background-image: url('{{ .Params.Bg_image | relURL }}');">
   <div class="container">
     <div class="row">
       <div class="col-md-12">

--- a/layouts/partials/service.html
+++ b/layouts/partials/service.html
@@ -1,4 +1,4 @@
-{{ with site.GetPage "/service"}}
+{{ with site.GetPage "/service" }}
 {{ with .Params.service }}
 <section class="service">
   <div class="container">

--- a/layouts/project/list.html
+++ b/layouts/project/list.html
@@ -17,7 +17,7 @@
               </label>
               {{ $categories := slice }}
               {{ range .Data.Pages }}
-              {{ $categories = $categories | append .Params.Category }}
+              {{ $categories = $categories | append .Params.category }}
               {{ end }}
               {{ range ( $categories | uniq ) }}
               <label class="btn btn-sm btn-primary">
@@ -28,7 +28,7 @@
           </div>
           <div class="row shuffle-wrapper">
             {{ range .Data.Pages }}
-            <div class="col-md-4 portfolio-item shuffle-item" data-groups="[&quot;{{ .Params.Category | urlize }}&quot;]">
+            <div class="col-md-4 portfolio-item shuffle-item" data-groups="[&quot;{{ .Params.category | urlize }}&quot;]">
               {{ if isset .Params "image" }}
               <img src="{{ .Params.image | relURL }}" alt="{{ .Title }}">
               {{ end }}
@@ -38,7 +38,7 @@
                   <a href="{{ . | relURL }}" class="portfolio-popup"><i class="icon ion-search"></i></a>
                   {{ end }}
                   <a class="h3" href="{{ .RelPermalink }}">{{ .Title }}</a>
-                  <p>{{ .Params.Description }}</p>
+                  <p>{{ .Params.description }}</p>
                 </div>
               </div>
             </div>

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -16,7 +16,7 @@
         <div class="project-details">
           <h4>Project Details</h4>
           <ul>
-            {{ range .Params.Information }}
+            {{ range .Params.information }}
             <li><span>{{ .label }} :</span> <strong>{{ .info | markdownify }}</strong></li>
             {{ end }}
           </ul>


### PR DESCRIPTION
- Add space after `{{` and before `}}`
- Always lowercase `.Params` names, cf. https://github.com/themefisher/airspace-hugo/pull/116