### PR TITLE
Fix HTML in about section on service page

### DIFF
--- a/layouts/_default/service.html
+++ b/layouts/_default/service.html
@@ -9,7 +9,7 @@
     <div class="row">
       <div class="col-md-6">
         {{ with .title }}<h2>{{ . | markdownify }}</h2>{{ end }}
-        {{ with .content }}<p class="mt-30">{{ . | markdownify }}</p>{{ end }}
+        {{ with .content }}<div class="mt-30">{{ . | $.Page.RenderString (dict "display" "block") }}</div>{{ end }}
       </div>
       {{ with .image -}}
       <div class="col-md-6">


### PR DESCRIPTION
When key `about.content` in the content file `service.md` is set to a multi-line string, the template generated invalid HTML (which some browsers automatically correct when rendering the page).

This PR fixes the template to *always* generate valid HTML regardless of `about.content`'s line count.