### PR TITLE
Move footer menu definitions to content files

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -182,43 +182,12 @@ contentDir = "content/english"
 weight = 1
 copyright = "Copyright &copy; 2021 [Themefisher](https://themefisher.com). All Rights Reserved."
 
-# Main menu
+# Navigation menus
 # NOTE: Leaf entries linking to content should be defined in the content file's respective front matter.
 [[languages.en.menu.main]]
 hasChildren = true
 name = "More"
 weight = 5
-
-# Footer menu
-[[languages.en.menu.footer]]
-name = "About"
-URL = "about"
-weight = 1
-
-[[languages.en.menu.footer]]
-name = "Project"
-URL = "project"
-weight = 2
-
-[[languages.en.menu.footer]]
-name = "Service"
-URL = "service"
-weight = 3
-
-[[languages.en.menu.footer]]
-name = "Pricing"
-URL = "pricing"
-weight = 4
-
-[[languages.en.menu.footer]]
-name = "FAQ"
-URL = "faq"
-weight = 5
-
-[[languages.en.menu.footer]]
-name = "Contact"
-URL = "contact"
-weight = 6
 
 
 ################################# French translation ##########################
@@ -229,43 +198,12 @@ contentDir = "content/french"
 weight = 2
 copyright = "Copyright &copy; 2021 [Themefisher](https://themefisher.com). Tous droits réservés."
 
-# Main menu
+# Navigation menus
 # NOTE: Leaf entries linking to content should be defined in the content file's respective front matter.
 [[languages.fr.menu.main]]
 hasChildren = true
 weight = 5
 name = "Plus"
-
-# Footer menu
-[[languages.fr.menu.footer]]
-name = "À propos"
-URL = "about"
-weight = 1
-
-[[languages.fr.menu.footer]]
-name = "Projet"
-URL = "project"
-weight = 2
-
-[[languages.fr.menu.footer]]
-name = "Service"
-URL = "service"
-weight = 3
-
-[[languages.fr.menu.footer]]
-name = "Tarification"
-URL = "pricing"
-weight = 4
-
-[[languages.fr.menu.footer]]
-name = "Questions fréquentes"
-URL = "faq"
-weight = 5
-
-[[languages.fr.menu.footer]]
-name = "Contact"
-URL = "contact"
-weight = 6
 
 
 ################################# Italian translation ##########################
@@ -276,43 +214,12 @@ contentDir = "content/italian"
 weight = 2
 copyright = "Copyright &copy; 2021 [Themefisher](https://themefisher.com). Tutti i diritti riservati."
 
-# Main menu
+# Navigation menus
 # NOTE: Leaf entries linking to content should be defined in the content file's respective front matter.
 [[languages.it.menu.main]]
 hasChildren = true
 weight = 5
 name = "Più"
-
-# Footer menu
-[[languages.it.menu.footer]]
-name = "Chi siamo"
-URL = "about"
-weight = 1
-
-[[languages.it.menu.footer]]
-name = "Progetto"
-URL = "project"
-weight = 2
-
-[[languages.it.menu.footer]]
-name = "Servizio"
-URL = "service"
-weight = 3
-
-[[languages.it.menu.footer]]
-name = "Tariffazione"
-URL = "pricing"
-weight = 4
-
-[[languages.it.menu.footer]]
-name = "Domande frequenti"
-URL = "faq"
-weight = 5
-
-[[languages.it.menu.footer]]
-name = "Contatta"
-URL = "contact"
-weight = 6
 
 
 ################################# German translation ##########################
@@ -323,40 +230,9 @@ contentDir = "content/german"
 weight = 3
 copyright = "Copyright &copy; 2021 [Themefisher](https://themefisher.com). Alle Rechte vorbehalten."
 
-# Main menu
+# Navigation menus
 # NOTE: Leaf entries linking to content should be defined in the content file's respective front matter.
 [[languages.de.menu.main]]
 hasChildren = true
 name = "Mehr"
 weight = 5
-
-# Footer menu
-[[languages.de.menu.footer]]
-name = "Über uns"
-URL = "about"
-weight = 1
-
-[[languages.de.menu.footer]]
-name = "Projekt"
-URL = "project"
-weight = 2
-
-[[languages.de.menu.footer]]
-name = "Dienstleistung"
-URL = "service"
-weight = 3
-
-[[languages.de.menu.footer]]
-name = "Preise"
-URL = "pricing"
-weight = 4
-
-[[languages.de.menu.footer]]
-name = "Häufige Fragen"
-URL = "faq"
-weight = 5
-
-[[languages.de.menu.footer]]
-name = "Kontakt"
-URL = "contact"
-weight = 6

--- a/exampleSite/content/english/about.md
+++ b/exampleSite/content/english/about.md
@@ -8,6 +8,9 @@ menu:
   main:
     name: "About"
     weight: 2
+  footer:
+    name: "About"
+    weight: 1
 
 
 ################################## About #####################################

--- a/exampleSite/content/english/contact.md
+++ b/exampleSite/content/english/contact.md
@@ -8,4 +8,7 @@ menu:
   main:
     name: "Contact"
     weight: 6
+  footer:
+    name: "Contact"
+    weight: 6
 ---

--- a/exampleSite/content/english/faq.md
+++ b/exampleSite/content/english/faq.md
@@ -11,6 +11,9 @@ menu:
     parent: "More"
     name: "FAQ"
     weight: 3
+  footer:
+    name: "FAQ"
+    weight: 5
 ---
 
 ### Welcome to Airspace!

--- a/exampleSite/content/english/pricing.md
+++ b/exampleSite/content/english/pricing.md
@@ -9,6 +9,9 @@ menu:
     parent: "More"
     name: "Pricing"
     weight: 2
+  footer:
+    name: "Pricing"
+    weight: 4
 
 ################################ pricing ################################
 pricing:

--- a/exampleSite/content/english/project/_index.md
+++ b/exampleSite/content/english/project/_index.md
@@ -7,4 +7,7 @@ menu:
   main:
     name: "Project"
     weight: 3
+  footer:
+    name: "Project"
+    weight: 2
 ---

--- a/exampleSite/content/english/service.md
+++ b/exampleSite/content/english/service.md
@@ -9,6 +9,9 @@ menu:
     parent: "More"
     name: "Service"
     weight: 1
+  footer:
+    name: "Service"
+    weight: 3
 
 ########################### about service #############################
 about:

--- a/exampleSite/content/french/about.md
+++ b/exampleSite/content/french/about.md
@@ -8,6 +8,9 @@ menu:
   main:
     name: "À propos"
     weight: 2
+  footer:
+    name: "À propos"
+    weight: 1
 
 
 ################################## About #####################################

--- a/exampleSite/content/french/contact.md
+++ b/exampleSite/content/french/contact.md
@@ -8,4 +8,7 @@ menu:
   main:
     name: "Contact"
     weight: 6
+  footer:
+    name: "Contact"
+    weight: 6
 ---

--- a/exampleSite/content/french/faq.md
+++ b/exampleSite/content/french/faq.md
@@ -11,6 +11,9 @@ menu:
     parent: "Plus"
     name: "Questions fréquentes"
     weight: 3
+  footer:
+    name: "Questions fréquentes"
+    weight: 5
 ---
 
 ### Welcome to Airspace!

--- a/exampleSite/content/french/pricing.md
+++ b/exampleSite/content/french/pricing.md
@@ -9,6 +9,9 @@ menu:
     parent: "Plus"
     name: "Tarification"
     weight: 2
+  footer:
+    name: "Tarification"
+    weight: 4
 
 ################################ pricing ################################
 pricing:

--- a/exampleSite/content/french/project/_index.md
+++ b/exampleSite/content/french/project/_index.md
@@ -7,4 +7,7 @@ menu:
   main:
     name: "Projet"
     weight: 3
+  footer:
+    name: "Projet"
+    weight: 2
 ---

--- a/exampleSite/content/french/service.md
+++ b/exampleSite/content/french/service.md
@@ -9,6 +9,9 @@ menu:
     parent: "Plus"
     name: "Service"
     weight: 1
+  footer:
+    name: "Service"
+    weight: 3
 
 ########################### about service #############################
 about:

--- a/exampleSite/content/german/about.md
+++ b/exampleSite/content/german/about.md
@@ -8,6 +8,9 @@ menu:
   main:
     name: "Über uns"
     weight: 2
+  footer:
+    name: "Über uns"
+    weight: 1
 
 
 ################################## About #####################################

--- a/exampleSite/content/german/contact.md
+++ b/exampleSite/content/german/contact.md
@@ -8,4 +8,7 @@ menu:
   main:
     name: "Kontakt"
     weight: 6
+  footer:
+    name: "Kontakt"
+    weight: 6
 ---

--- a/exampleSite/content/german/faq.md
+++ b/exampleSite/content/german/faq.md
@@ -11,6 +11,9 @@ menu:
     parent: "Mehr"
     name: "Häufige Fragen"
     weight: 3
+  footer:
+    name: "Häufige Fragen"
+    weight: 5
 ---
 
 ### Welcome to Airspace!

--- a/exampleSite/content/german/pricing.md
+++ b/exampleSite/content/german/pricing.md
@@ -9,6 +9,9 @@ menu:
     parent: "Mehr"
     name: "Preise"
     weight: 2
+  footer:
+    name: "Preise"
+    weight: 4
 
 ################################ pricing ################################
 pricing:

--- a/exampleSite/content/german/project/_index.md
+++ b/exampleSite/content/german/project/_index.md
@@ -7,4 +7,7 @@ menu:
   main:
     name: "Projekt"
     weight: 3
+  footer:
+    name: "Projekt"
+    weight: 2
 ---

--- a/exampleSite/content/german/service.md
+++ b/exampleSite/content/german/service.md
@@ -9,6 +9,9 @@ menu:
     parent: "Mehr"
     name: "Dienstleistung"
     weight: 1
+  footer:
+    name: "Dienstleistung"
+    weight: 3
 
 ########################### about service #############################
 about:

--- a/exampleSite/content/italian/about.md
+++ b/exampleSite/content/italian/about.md
@@ -8,6 +8,9 @@ menu:
   main:
     name: "Chi siamo"
     weight: 2
+  footer:
+    name: "Chi siamo"
+    weight: 1
 
 
 ################################## About #####################################

--- a/exampleSite/content/italian/contact.md
+++ b/exampleSite/content/italian/contact.md
@@ -8,4 +8,7 @@ menu:
   main:
     name: "Contatta"
     weight: 6
+  footer:
+    name: "Contatta"
+    weight: 6
 ---

--- a/exampleSite/content/italian/faq.md
+++ b/exampleSite/content/italian/faq.md
@@ -11,6 +11,9 @@ menu:
     parent: "More"
     name: "Domande frequenti"
     weight: 3
+  footer:
+    name: "Domande frequenti"
+    weight: 5
 ---
 
 ### Welcome to Airspace!

--- a/exampleSite/content/italian/pricing.md
+++ b/exampleSite/content/italian/pricing.md
@@ -9,6 +9,9 @@ menu:
     parent: "More"
     name: "Tariffazione"
     weight: 2
+  footer:
+    name: "Tariffazione"
+    weight: 4
 
 ################################ pricing ################################
 pricing:

--- a/exampleSite/content/italian/project/_index.md
+++ b/exampleSite/content/italian/project/_index.md
@@ -7,4 +7,7 @@ menu:
   main:
     name: "Progetto"
     weight: 3
+  footer:
+    name: "Progetto"
+    weight: 2
 ---

--- a/exampleSite/content/italian/service.md
+++ b/exampleSite/content/italian/service.md
@@ -9,6 +9,9 @@ menu:
     parent: "More"
     name: "Servizio"
     weight: 1
+  footer:
+    name: "Servizio"
+    weight: 3
 
 ########################### about service #############################
 about:


### PR DESCRIPTION
This simplifies menu adjustments since the content and its menu entries are now all found in the same place. E.g. you can now simply set `draft = true` in a specific content file and all its menu entries will automatically be disabled (i.e. have draft status), too, without the extra need to modify `config.toml` anymore.

Cf. #149