### PR TITLE
Set default `timeZone`

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,6 +3,8 @@
 baseURL = "http://examplesite.org"
 title = "Airspace | Creative Agency Hugo Template"
 theme = "airspace-hugo"
+# Default time zone for time stamps; use any valid [tz database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)
+timeZone = "UTC"
 # Number of posts per page in list view
 paginate = "4"
 # Post excerpt length


### PR DESCRIPTION
cf. https://gohugo.io/getting-started/configuration/#timezone

Depends on #185 which increases the minimally required Hugo version to v0.87.0.