### PR TITLE
Link to webmanifest in lang sub-directory

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -51,7 +51,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="{{$favicon_180.RelPermalink}}">
 {{ end }}
 {{ end }}
-<link rel="manifest" href="{{`manifest.webmanifest` | relURL }}">
+<link rel="manifest" href="{{`manifest.webmanifest` | relLangURL }}">
 <meta name="msapplication-TileColor" content="{{site.Params.variables.color_primary | default `#da532c`}}">
 <meta name="theme-color" content="{{site.Params.variables.body_color | default `#ffffff` }}">
 


### PR DESCRIPTION
There is one `manifest.webmanifest` generated per language, then link to the manifest of the current language.