### PR TITLE
Use matomo.{js,php} in matomo tracking code

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -127,14 +127,14 @@
   _paq.push(['enableLinkTracking']);
   (function () {
     var u = "{{.url|safeURL}}";
-    _paq.push(['setTrackerUrl', u + 'piwik.php']);
+    _paq.push(['setTrackerUrl', u + 'matomo.php']);
     _paq.push(['setSiteId', '{{.id}}']);
     var d = document,
       g = d.createElement('script'),
       s = d.getElementsByTagName('script')[0];
     g.type = 'text/javascript';
     g.async = true;
-    g.src = u + 'piwik.js';
+    g.src = u + 'matomo.js';
     s.parentNode.insertBefore(g, s);
   })();
 </script>


### PR DESCRIPTION
The Matomo documentation states the tracking code should use matomo named files:

https://developer.matomo.org/guides/tracking-javascript-guide

The `piwik.*` files are still available in latest versions of Matomo but I suspect they could remove them at any time since they are incrementally getting rid ot this old name.