### PR TITLE
Update counter.dev analytics

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -79,7 +79,8 @@ domain = "" # yourdomain.com
 # counter analytics: see https://counter.dev/setup.html
 [counter]
 enable = false
-username = "" # your username
+id = "" # your site's counter.dev ID (`data-id` attribute value)
+utc_offset = 0 # UTC time offset (`data-utcoffset` attribute value)
 
 # site verifications
 [site_verification]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -163,19 +163,19 @@
 {{ end }}
 
 <!-- Plausible Analytics -->
-{{ if site.Params.plausible.enable }}
-{{ with site.Params.plausible.domain }}
+{{ with site.Params.plausible }}
+{{ if .enable }}
+{{ with .domain }}
 <script defer data-domain="{{ . }}" src="https://plausible.io/js/plausible.js"></script>
+{{ end }}
 {{ end }}
 {{ end }}
 
 <!-- Counter Analytics -->
 {{ with site.Params.counter }}
 {{ if .enable }}
-{{ with .username }}
-<script>
-  if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.dev/track?"+new URLSearchParams({referrer:document.referrer,screen:screen.width+"x"+screen.height,user:"{{ . }}",utcoffset:"0"}))};sessionStorage.setItem("_swa","1");
-</script>
+{{ with .id }}
+<script src="https://cdn.counter.dev/script.js" data-id="{{ . }}" data-utcoffset="{{ site.Params.counter.utc_offset | default "0" }}"></script>
 {{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
counter.dev recently switched to using an external script, cf. https://counter.dev/blog/external-tracking-script.html

Additionally made sure that the site successfully builds in case the `params.plausible` config is absent.