### PR TITLE
:bar_chart: Analytics: Support Umami Analytics

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -82,6 +82,12 @@ enable = false
 id = "" # your site's counter.dev ID (`data-id` attribute value)
 utc_offset = 0 # UTC time offset (`data-utcoffset` attribute value)
 
+# umami analytics: see https://umami.is/
+[umami]
+enable = true
+# url = "https://cloud.umami.is/script.js" # allows user to select a self-hosted location instead of umami cloud
+id = "fe1a3b86-8826-4231-8fff-fe0e98c970d4" # umami website ID
+
 # site verifications
 [site_verification]
 google = "" # Your verification code

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -84,9 +84,9 @@ utc_offset = 0 # UTC time offset (`data-utcoffset` attribute value)
 
 # umami analytics: see https://umami.is/
 [umami]
-enable = true
+enable = false # set to true to enable umami
 # url = "https://cloud.umami.is/script.js" # allows user to select a self-hosted location instead of umami cloud
-id = "fe1a3b86-8826-4231-8fff-fe0e98c970d4" # umami website ID
+id = "" # umami website ID
 
 # site verifications
 [site_verification]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -191,6 +191,15 @@
 {{ end }}
 {{ end }}
 
+<!-- Umami Analytics -->
+{{ with site.Params.umami }}
+{{ if .enable }}
+{{ with .id }}
+<script defer src="{{ site.Params.umami.url | default "https://cloud.umami.is/script.js" }}" data-website-id="{{ . }}"></script>  <!-- enables user to change script location if self-hosting -->
+{{ end }}
+{{ end }}
+{{ end }}
+
 <!-- Google reCaptcha -->
 {{ if site.Params.contact.form.use_recaptcha }}
 <script src="https://www.google.com/recaptcha/api.js?render={{ site.Params.recaptcha_site_key }}"></script>


### PR DESCRIPTION
### Support for Umami Analytics (https://umami.is)

[Umami ](https://umami.is)analytics can be used with Umami Cloud or by self hosting umami. 
Hugo configuration supports default umami cloud or self-hosted url through setting params.toml variable

**Update to `head.html`**
```html
<!-- Umami Analytics -->
{{ with site.Params.umami }}
{{ if .enable }}
{{ with .id }}
<script defer src="{{ site.Params.umami.url | default "https://cloud.umami.is/script.js" }}" data-website-id="{{ . }}"></script>  <!-- enables user to change script location if self-hosting -->
{{ end }}
{{ end }}
{{ end }}
```

**Setting umami variables in `params.toml`**

```toml
# umami analytics: see https://umami.is/
[umami]
enable = false # set to 'true' to enable umami
# url = "https://cloud.umami.is/script.js" # allows user to select a self-hosted location instead of umami cloud
id = "" # umami website ID
```